### PR TITLE
refactor: Ratings response cache

### DIFF
--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -10,7 +10,7 @@ export enum RatingResultStatus {
   Found = 'found'
 }
 
-export type GetRating = {
+export type RatingRequest = {
   query: ProductType
   productName: string
 }


### PR DESCRIPTION
Moved the logic for tryGetting the cache, and setting a cache, into the generic fetchRating function.
Instead of having to handle that logic in each API integration.

Changed the cache key to instead use the RequestRating type instead of the request URL