### PR TITLE
fix: Broken Vivino integration

### DIFF
--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -26,3 +26,21 @@ export interface RatingResponse {
   status: RatingResultStatus
   votes: number
 }
+
+export interface VivinoMatch {
+  vintage: {
+    id: number
+    name: string
+    region?: {
+      name: string
+    }
+    statistics: {
+      ratings_average: null | number
+      ratings_count: null | number
+    }
+  }
+}
+
+export interface VivinoReponseJSON {
+  search_results?: { matches: VivinoMatch[] }
+}

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -3,7 +3,9 @@ import {
   ProductType,
   RatingRequest,
   RatingResponse,
-  RatingResultStatus
+  RatingResultStatus,
+  VivinoMatch,
+  VivinoReponseJSON
 } from '@/@types/types'
 import * as cheerio from 'cheerio'
 import stringSimilarity from 'string-similarity'
@@ -101,19 +103,16 @@ export async function fetchRatingFromUntappd(
     return { status: RatingResultStatus.NotFound } as RatingResponse
   }
 }
-
 export async function fetchRatingFromVivino(
   query: string
 ): Promise<null | RatingResponse> {
-  const url = `https://www.vivino.com/search/wines?q=${encodeURIComponent(
-    query
-  )}`
+  const url = `https://www.vivino.com/search/wines?q=${encodeURIComponent(query)}`
 
   try {
     const response = await fetch(url, {
       headers: {
         'User-Agent':
-          'Mozilla/5.0 (Windows NT 10.0 Win64 x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3'
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3'
       }
     })
 
@@ -124,55 +123,66 @@ export async function fetchRatingFromVivino(
     const html = await response.text()
     const $ = cheerio.load(html)
 
-    // Extracting wine card elements
-    const wineCard = $('.default-wine-card').first()
-    const name = wineCard.find('.wine-card__name').first().text().trim()
+    // Find the `data-preloaded-state` attribute
+    const searchPageElement = $('#search-page')
+    if (!searchPageElement.length) {
+      return { status: RatingResultStatus.NotFound } as RatingResponse
+    }
+    const preloadedState = searchPageElement.attr('data-preloaded-state')
+    if (!preloadedState) {
+      return { status: RatingResultStatus.NotFound } as RatingResponse
+    }
 
-    const similarityRate = stringSimilarity.compareTwoStrings(query, name)
-    if (similarityRate < 0.5) {
+    const data = JSON.parse(preloadedState) as VivinoReponseJSON
+
+    const matches = data.search_results?.matches ?? []
+    if (matches.length === 0) {
+      return { status: RatingResultStatus.NotFound } as RatingResponse
+    }
+
+    type Wine = RatingResponse & {
+      similarityRate: number
+    }
+    const bestMatch = matches.reduce<null | Wine>(
+      (best: null | Wine, match: VivinoMatch) => {
+        const wineName = match.vintage.name
+        const rating = match.vintage.statistics.ratings_average ?? -1
+        const votes = match.vintage.statistics.ratings_count ?? -1
+        const link = `https://www.vivino.com/wines/${match.vintage.id.toString()}`
+
+        // Calculate similarity rate
+        const similarityRate = stringSimilarity.compareTwoStrings(
+          query,
+          wineName
+        )
+
+        const current: Wine = {
+          link,
+          name: wineName,
+          rating,
+          similarityRate,
+          status: RatingResultStatus.Found,
+          votes
+        }
+
+        return similarityRate > (best?.similarityRate ?? 0) ? current : best
+      },
+      null
+    )
+
+    if (
+      !bestMatch ||
+      bestMatch.similarityRate < 0.5 ||
+      bestMatch.rating < 0 ||
+      bestMatch.votes < 0
+    ) {
       return {
         link: url,
         status: RatingResultStatus.Uncertain
       } as RatingResponse
     }
 
-    // Extracting average rating
-    const ratingRaw = wineCard
-      .find('.average__container .average__number')
-      .first()
-      .text()
-      .trim()
-      .replace(',', '.')
-
-    const rating = ratingRaw !== '-' ? Number.parseFloat(ratingRaw) : null
-    // Extracting number of ratings
-    const votesRaw = wineCard
-      .find('.average__stars .text-micro')
-      .first()
-      .text()
-      .trim()
-    const votes =
-      votesRaw.includes(' ratings') || votesRaw.includes(' betyg')
-        ? Number.parseInt(votesRaw.split(' ')[0])
-        : null
-
-    // TODO: Handle case when there are no/too few ratings
-
-    const linkElement =
-      wineCard
-        .find('a[data-cartitemsource="text-search"]')
-        .first()
-        .attr('href') ?? ''
-    const link = `https://www.vivino.com/${linkElement}`
-    const vivinoResponse = {
-      link,
-      name,
-      rating,
-      status: RatingResultStatus.Found,
-      votes
-    } as RatingResponse
-
-    return vivinoResponse
+    return bestMatch
   } catch {
     return { status: RatingResultStatus.NotFound } as RatingResponse
   }


### PR DESCRIPTION
- Was unable to fetch Vivino ratings on Firefox/Chrome desktop, though it worked on Firefox Android.
- Vivino's webpage layout changes dynamically, with custom CSS class suffixes and no rendered HTML for wine data (could not read the HTML elements using cheerio)
- Might be something going on at Vivino? If a cookie is set, if you are redirected depending on that (Swedish/English set etc.)?

**Solution:** This PR uses the data-preloaded-state attribute to extract wine data directly from the JSON before rendering.
Might have to roll this back, or extend the Vivino integration with a combination of the old solution, and this new solution.


--- 
Also, an additional small change. All found wines are now evaluated using a string similarity check, and the best match is returned instead of the first result



