### PR TITLE
test: add e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,3 +33,5 @@ jobs:
         run: pnpm lint
       # - name: Run tests
       #   run: pnpm test
+      # - name: run e2e tests
+      #   run: pnpm e2e

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,15 +12,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
         with:
-          node-version: lts/*
+          version: 10
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: pnpm playwright install --with-deps
+      # - name: Install xvfb
+      # run: sudo apt-get install -y xvfb
+      - name: Build the project
+        run: pnpm build:chrome
       - name: Run Playwright tests
-        run: npx playwright test
+        run: xvfb-run pnpm playwright test
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,6 +6,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+permissions:
+  contents: read
 jobs:
   test:
     timeout-minutes: 60
@@ -25,8 +27,6 @@ jobs:
         run: pnpm install
       - name: Install Playwright Browsers
         run: pnpm playwright install --with-deps
-      # - name: Install xvfb
-      # run: sudo apt-get install -y xvfb
       - name: Build the project
         run: pnpm build:chrome
       - name: Run Playwright tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,29 @@
+name: Playwright Tests
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Run Playwright tests
+        run: npx playwright test
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ web-ext.config.ts
 *.sln
 *.sw?
 
+# playwright
+playwright-report/
+test-results/.last-run.json

--- a/e2e/end-to-end.spec.ts
+++ b/e2e/end-to-end.spec.ts
@@ -19,7 +19,7 @@ test('visiting wine page shows rating-container', async ({
   await page.waitForSelector('#rating-container')
 
   // assert
-  assert(page.locator('#rating-container'))
+  await expect(page.locator('#rating-container')).toBeVisible()
 })
 
 test('visiting beer page shows rating-container with votes', async ({
@@ -64,7 +64,8 @@ test('visiting a wine page with wine toggle disabled should not show wine', asyn
   await page.reload()
 
   // assert
-  assert(!page.locator('#rating-container'))
+  // assert(!page.locator('#rating-container'))
+  await expect(page.locator('#rating-container')).not.toBeVisible()
 })
 
 //TODO: Add a test that checks a wine page and also checks that there is a

--- a/e2e/end-to-end.spec.ts
+++ b/e2e/end-to-end.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from './fixtures'
+import { assert } from 'console'
+
+test('visiting wine page shows rating-container', async ({
+  page,
+  extensionId
+}) => {
+  // arrange
+  await page.goto(`chrome-extension://${extensionId}/popup.html`)
+  await page.waitForSelector('.settings')
+  await expect(page.locator('#enabled')).toBeChecked()
+  await expect(page.locator('#wine')).toBeChecked()
+
+  // act
+  await page.goto('https://www.systembolaget.se/produkt/vin/amadio-203701/')
+  await page.getByRole('link', { name: 'Jag har fyllt 20 år' }).click()
+  await page.getByRole('button', { name: 'Slå på och acceptera alla' }).click()
+  await page.reload()
+  await page.waitForSelector('#rating-container')
+
+  // assert
+  assert(page.locator('#rating-container'))
+})
+
+test('visiting beer page shows rating-container with votes', async ({
+  page,
+  extensionId
+}) => {
+  // arrange
+  await page.goto(`chrome-extension://${extensionId}/popup.html`)
+  await page.waitForSelector('.settings')
+  await expect(page.locator('#enabled')).toBeChecked()
+  await expect(page.locator('#beer')).toBeChecked()
+
+  // act
+  await page.goto('https://www.systembolaget.se/produkt/ol/pabst-155315/')
+  await page.getByRole('link', { name: 'Jag har fyllt 20 år' }).click()
+  await page.getByRole('button', { name: 'Slå på och acceptera alla' }).click()
+  await page.reload()
+  await page.locator('#rating-container').waitFor()
+
+  // assert
+  const res = await page.locator('#rating-container').textContent()
+  assert(res?.includes('röster'))
+})
+
+test('visiting a wine page with wine toggle disabled should not show wine', async ({
+  page,
+  extensionId
+}) => {
+  // arrange
+  await page.goto(`chrome-extension://${extensionId}/popup.html`)
+  await page.waitForSelector('.settings')
+
+  await expect(page.locator('#enabled')).toBeChecked()
+  await expect(page.locator('#wine')).toBeChecked()
+  await page.locator('div:nth-child(2) > .switch > .slider').click()
+  await expect(page.locator('#wine')).not.toBeChecked()
+
+  // act
+  await page.goto('https://www.systembolaget.se/produkt/vin/amadio-203701/')
+  await page.getByRole('link', { name: 'Jag har fyllt 20 år' }).click()
+  await page.getByRole('button', { name: 'Slå på och acceptera alla' }).click()
+  await page.reload()
+
+  // assert
+  assert(!page.locator('#rating-container'))
+})
+
+//TODO: Add a test that checks a wine page and also checks that there is a
+// rating-container with votes. Blocked by https://github.com/BroadcastDivers/bolaget-plus/pull/56

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -9,6 +9,7 @@ export const test = base.extend<{
 }>({
   context: async ({}, use) => {
     const context = await chromium.launchPersistentContext('', {
+      channel: 'chromium',
       headless: false,
       args: [
         `--disable-extensions-except=${pathToExtension}`,

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,35 @@
+import { test as base, chromium, type BrowserContext } from '@playwright/test'
+import path from 'path'
+
+const pathToExtension = path.resolve('.output/chrome-mv3')
+
+export const test = base.extend<{
+  context: BrowserContext
+  extensionId: string
+}>({
+  context: async ({}, use) => {
+    const context = await chromium.launchPersistentContext('', {
+      headless: false,
+      args: [
+        `--disable-extensions-except=${pathToExtension}`,
+        `--load-extension=${pathToExtension}`
+      ]
+    })
+    await use(context)
+    await context.close()
+  },
+  extensionId: async ({ context }, use) => {
+    let background: { url(): string }
+    if (pathToExtension.endsWith('-mv3')) {
+      ;[background] = context.serviceWorkers()
+      if (!background) background = await context.waitForEvent('serviceworker')
+    } else {
+      ;[background] = context.backgroundPages()
+      if (!background) background = await context.waitForEvent('backgroundpage')
+    }
+
+    const extensionId = background.url().split('/')[2]
+    await use(extensionId)
+  }
+})
+export const expect = test.expect

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ft": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
     "lint": "eslint src/**/*.{js,jsx,ts,tsx}",
     "lint:fix": "eslint src/**/*.{js,jsx,ts,tsx} --fix",
-    "e2e": "playwright test",
+    "e2e": "pnpm build:chrome && playwright test",
     "e2eui": "playwright test --ui"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,16 +16,20 @@
     "postinstall": "wxt prepare",
     "ft": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
     "lint": "eslint src/**/*.{js,jsx,ts,tsx}",
-    "lint:fix": "eslint src/**/*.{js,jsx,ts,tsx} --fix"
+    "lint:fix": "eslint src/**/*.{js,jsx,ts,tsx} --fix",
+    "e2e": "playwright test",
+    "e2eui": "playwright test --ui"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
+    "@playwright/test": "^1.51.1",
     "@types/chrome": "^0.0.280",
     "@types/string-similarity": "^4.0.2",
     "@types/webextension-polyfill": "^0.12.1",
     "@wxt-dev/auto-icons": "^1.0.2",
     "eslint": "^9.20.1",
     "eslint-plugin-perfectionist": "^4.9.0",
+    "playwright": "^1.51.1",
     "prettier": "^3.5.1",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.24.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: 'e2e',
+  // Fail the build on CI if you accidentally left test.only in the source code.
+  forbidOnly: !!process.env.CI,
+  // Retry on CI only.
+  retries: process.env.CI ? 2 : 0,
+  // Opt out of parallel tests on CI.
+  workers: process.env.CI ? 1 : undefined,
+  // Reporter to use
+  reporter: 'html',
+  use: {
+    // Collect trace when retrying the failed test.
+    trace: 'on-first-retry'
+  },
+  // Configure projects for major browsers.
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ]
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,8 @@ export default defineConfig({
   reporter: 'html',
   use: {
     // Collect trace when retrying the failed test.
-    trace: 'on-first-retry'
+    trace: 'on-first-retry',
+    headless: true
   },
   // Configure projects for major browsers.
   projects: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@eslint/js':
         specifier: ^9.20.0
         version: 9.20.0
+      '@playwright/test':
+        specifier: ^1.51.1
+        version: 1.51.1
       '@types/chrome':
         specifier: ^0.0.280
         version: 0.0.280
@@ -42,6 +45,9 @@ importers:
       eslint-plugin-perfectionist:
         specifier: ^4.9.0
         version: 4.9.0(eslint@9.20.1(jiti@1.21.7))(typescript@5.7.3)
+      playwright:
+        specifier: ^1.51.1
+        version: 1.51.1
       prettier:
         specifier: ^3.5.1
         version: 3.5.1
@@ -729,6 +735,11 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@playwright/test@1.51.1':
+    resolution: {integrity: sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -1587,6 +1598,11 @@ packages:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2299,6 +2315,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.51.1:
+    resolution: {integrity: sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.51.1:
+    resolution: {integrity: sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
@@ -3360,6 +3386,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.0
 
+  '@playwright/test@1.51.1':
+    dependencies:
+      playwright: 1.51.1
+
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/network.ca-file@1.0.2':
@@ -4335,6 +4365,9 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5020,6 +5053,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.7.4
       pathe: 2.0.3
+
+  playwright-core@1.51.1: {}
+
+  playwright@1.51.1:
+    dependencies:
+      playwright-core: 1.51.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.3:
     dependencies:

--- a/src/entrypoints/popup/index.html
+++ b/src/entrypoints/popup/index.html
@@ -33,21 +33,21 @@
                 <div class="toggle-container">
                     <span class="toggle-label">Aktiverad</span>
                     <label class="switch">
-                        <input type="checkbox" id="enabled">
+                        <input type="checkbox" id="enabled" name="enabled">
                         <span class="slider"></span>
                     </label>
                 </div>
                 <div class="toggle-container">
                     <span class="toggle-label">Vin</span>
                     <label class="switch">
-                        <input type="checkbox" id="wine">
+                        <input type="checkbox" id="wine" name="wine">
                         <span class="slider"></span>
                     </label>
                 </div>
                 <div class="toggle-container">
                     <span class="toggle-label">Öl</span>
                     <label class="switch">
-                        <input type="checkbox" id="beer">
+                        <input type="checkbox" id="beer" name="beer">
                         <span class="slider"></span>
                     </label>
                 </div>


### PR DESCRIPTION
implements the e2e test for the Chrome version (unfortunately, Firefox is not supported).  Nevertheless, it navigates to the pages for beer and wine and performs some simple tests. 

As an example, one test turns off wine and then verifies that there isn't a rating container.  
A pipeline in workflows is set up to run once daily; the idea is that we should be alerted if Systembolaget breaks our plugin.