### PR TITLE
build(deps): bump vite to 6.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "cheerio": "^1.0.0",
     "sentinel-js": "^0.0.7",
     "string-similarity": "^4.0.4",
-    "vite": "^6.1.4"
+    "vite": "^6.2.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: ^4.0.4
         version: 4.0.4
       vite:
-        specifier: ^6.1.4
+        specifier: ^6.2.5
         version: 6.2.5(@types/node@22.13.2)(jiti@1.21.7)
     devDependencies:
       '@eslint/js':


### PR DESCRIPTION
Upgrade vite to fix [4 Dependabot alerts](https://github.com/BroadcastDivers/bolaget-plus/security/dependabot?q=is%3Aopen+package%3Avite+manifest%3Apnpm-lock.yaml+has%3Apatch) in [pnpm-lock.yaml](https://github.com/BroadcastDivers/bolaget-plus/blob/-/pnpm-lock.yaml)