### PR TITLE
chore: add simple-git-hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Install dependencies with [pnpm](https://pnpm.io/)
 
 ```sh
 pnpm install
+# Git hooks will be automatically installed
 ```
 
 Run it in either Chrome or Firefox:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "author": "BroadcastDivers",
   "scripts": {
+    "prepare": "simple-git-hooks && wxt prepare",
     "dev:chrome": "wxt",
     "dev:firefox": "wxt -b firefox",
     "build:chrome": "wxt build",
@@ -13,7 +14,6 @@
     "zip:chrome": "wxt zip",
     "zip:firefox": "wxt zip -b firefox",
     "compile": "tsc --noEmit",
-    "postinstall": "wxt prepare",
     "ft": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
     "lint": "eslint src/**/*.{js,jsx,ts,tsx}",
     "lint:fix": "eslint src/**/*.{js,jsx,ts,tsx} --fix",
@@ -31,6 +31,7 @@
     "eslint-plugin-perfectionist": "^4.9.0",
     "playwright": "^1.51.1",
     "prettier": "^3.5.1",
+    "simple-git-hooks": "^2.12.1",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.24.0",
     "webextension-polyfill": "^0.12.0",
@@ -42,5 +43,8 @@
     "sentinel-js": "^0.0.7",
     "string-similarity": "^4.0.4",
     "vite": "^6.2.5"
+  },
+  "simple-git-hooks": {
+    "pre-push": "pnpm run ft && pnpm run lint"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       prettier:
         specifier: ^3.5.1
         version: 3.5.1
+      simple-git-hooks:
+        specifier: ^2.12.1
+        version: 2.12.1
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
@@ -2528,6 +2531,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-git-hooks@2.12.1:
+    resolution: {integrity: sha512-NB3V4XyCOrWTIhjh85DyEoVlM3adHWwqQXKYHmuegy/108bJPP6YxuPGm4ZKBq1+GVKRbKJuzNY//09cMJYp+A==}
+    hasBin: true
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -5313,6 +5320,8 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  simple-git-hooks@2.12.1: {}
 
   simple-swizzle@0.2.2:
     dependencies:


### PR DESCRIPTION
closes #29 

Was thinking about using `husky`, but went with `simple-git-hooks`
![bild](https://github.com/user-attachments/assets/a4cd2dfc-3af6-4c22-8478-d841eb08a655)

![bild](https://github.com/user-attachments/assets/4d15b236-3f36-426a-896f-cf623bf89ed3)

