### PR TITLE
chore: include Android in Firefox manifest

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -45,6 +45,9 @@ export default defineConfig({
     browser_specific_settings: {
       gecko: {
         id: 'broadcastdivers@test.com'
+      },
+      gecko_android : {
+        strict_min_version: '120.0'
       }
     }
   }


### PR DESCRIPTION
Lets hope this is enough to automatically set each version to Android compatible. Without any manual intervention on the Firefox developer portal

Closing #74 