### PR TITLE
fix: resolve flaky e2e test for beer page ratings

### DIFF
--- a/e2e/end-to-end.spec.ts
+++ b/e2e/end-to-end.spec.ts
@@ -39,9 +39,12 @@ test('visiting beer page shows rating-container with votes', async ({
   await page.reload()
   await page.locator('#rating-container').waitFor()
 
+  // Wait for the spinner to be removed
+  await page.waitForSelector('.spinner', { state: 'detached' });
+  await page.waitForSelector('#rating-container-body');
   // assert
   const res = await page.locator('#rating-container').textContent()
-  assert(res?.includes('röster'))
+  expect(res).toMatch(/(votes|röster)/i)
 })
 
 test('visiting a wine page with wine toggle disabled should not show wine', async ({


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/74f05e9e-6268-4ad0-b766-39e57637d330)

After:
![image](https://github.com/user-attachments/assets/79f6f636-dcc4-4b06-ba60-c3d7ed0f264a)

Closing #39 