### PR TITLE
feat: redesign rating card and fix bottle detection for non-flaska formats

### DIFF
--- a/e2e/end-to-end.spec.ts
+++ b/e2e/end-to-end.spec.ts
@@ -40,7 +40,7 @@ test('visiting beer page shows rating-container with votes', async ({
   await page.locator('#rating-container').waitFor()
 
   // Wait for the spinner to be removed
-  await page.waitForSelector('.spinner', { state: 'detached' });
+  await page.waitForSelector('.bp-spinner', { state: 'detached' });
   await page.waitForSelector('#rating-container-body');
   // assert
   const res = await page.locator('#rating-container').textContent()
@@ -87,7 +87,7 @@ test('visiting a wine page shows rating-container with ratings and stars', async
   await page.reload();
 
   // Wait for the spinner to be removed
-  await page.waitForSelector('.spinner', { state: 'detached' });
+  await page.waitForSelector('.bp-spinner', { state: 'detached' });
 
   await page.waitForSelector('#rating-container-body');
 
@@ -95,7 +95,7 @@ test('visiting a wine page shows rating-container with ratings and stars', async
   const ratingContainer = page.locator('#rating-container-body');
   await expect(ratingContainer).toBeVisible();
 
-  const stars = ratingContainer.locator('svg');
+  const stars = ratingContainer.locator('.bp-rating-row svg');
   await expect(stars).toHaveCount(5);
 
   // Check for the presence of text indicating ratings (e.g., "votes" or "röster")

--- a/src/components/domUtils.ts
+++ b/src/components/domUtils.ts
@@ -4,6 +4,105 @@ import { BeerResponse, ProductType, RatingResponse } from '@/@types/types'
 
 const RATING_CONTAINER_ID = 'rating-container'
 const RATING_CONTAINER_BODY_ID = 'rating-container-body'
+const STYLE_ID = 'bolaget-plus-css'
+
+const STYLES = `
+  #${RATING_CONTAINER_ID} {
+    margin-top: 12px;
+    border: 1px solid #e3e3e3;
+    border-left: 4px solid #095741;
+    border-radius: 8px;
+    background: #ffffff;
+    font-family: inherit;
+    font-size: 14px;
+    color: #1a1a1a;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  }
+  #${RATING_CONTAINER_ID} .bp-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    font-weight: 600;
+    font-size: 13px;
+    letter-spacing: 0.2px;
+    color: #095741;
+    border-bottom: 1px solid #f0f0f0;
+  }
+  #${RATING_CONTAINER_ID} .bp-logo {
+    width: 12px;
+    height: 12px;
+    transform: rotate(45deg);
+    border-radius: 2px;
+    background: #095741;
+  }
+  #${RATING_CONTAINER_BODY_ID} {
+    padding: 10px 12px;
+  }
+  #${RATING_CONTAINER_ID} .bp-rating-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  #${RATING_CONTAINER_ID} .bp-score {
+    font-size: 20px;
+    font-weight: 700;
+    line-height: 1;
+  }
+  #${RATING_CONTAINER_ID} .bp-scale {
+    color: #888;
+    font-size: 13px;
+  }
+  #${RATING_CONTAINER_ID} .bp-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+  }
+  #${RATING_CONTAINER_ID} .bp-meta {
+    color: #666;
+    font-size: 12px;
+    line-height: 1.4;
+  }
+  #${RATING_CONTAINER_ID} .bp-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    color: #095741;
+    font-size: 13px;
+    font-weight: 500;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+  #${RATING_CONTAINER_ID} .bp-link:hover {
+    text-decoration: underline;
+  }
+  #${RATING_CONTAINER_ID} .bp-message {
+    color: #666;
+    text-align: center;
+    padding: 2px 0;
+  }
+  #${RATING_CONTAINER_ID} .bp-spinner-wrap {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 48px;
+    gap: 10px;
+  }
+  #${RATING_CONTAINER_ID} .bp-spinner {
+    width: 24px;
+    height: 24px;
+    border: 3px solid #e8e8e8;
+    border-top-color: #095741;
+    border-radius: 50%;
+    animation: bp-spin 0.8s linear infinite;
+  }
+  @keyframes bp-spin {
+    to { transform: rotate(360deg); }
+  }
+`
 
 export function getAndClearContainer(): HTMLElement {
   let container = document.getElementById(RATING_CONTAINER_BODY_ID)
@@ -22,12 +121,11 @@ export function injectRatingContainer() {
   }
   const ratingContainer = document.createElement('div')
   ratingContainer.id = RATING_CONTAINER_ID
-  ratingContainer.style.cssText =
-    'background-color: #fff3cd; padding: 10px; margin-top: 10px; border: 1px solid #ffeeba; border-radius: 4px; font-family: Arial, sans-serif; font-size: 14px;'
 
-  const header = '<h3 style="color: #856404; text-align: center;">Bolaget+</h3>'
-
-  ratingContainer.innerHTML = header
+  const header = document.createElement('div')
+  header.className = 'bp-header'
+  header.innerHTML = `<span class="bp-logo"></span><span>Bolaget+</span>`
+  ratingContainer.appendChild(header)
 
   const bodyDiv = document.createElement('div')
   bodyDiv.id = RATING_CONTAINER_BODY_ID
@@ -41,15 +139,10 @@ export function injectRatingContainer() {
     )
   }
 
-  if (!document.getElementById('spinner-css')) {
+  if (!document.getElementById(STYLE_ID)) {
     const style = document.createElement('style')
-    style.id = 'spinner-css'
-    style.innerHTML = `
-        @keyframes spin {
-          0% { transform: rotate(0deg); }
-          100% { transform: rotate(360deg); }
-        }
-      `
+    style.id = STYLE_ID
+    style.textContent = STYLES
     document.head.appendChild(style)
   }
 }
@@ -59,7 +152,7 @@ export function setMessage(message: string) {
   if (!ratingContainer) {
     return
   }
-  ratingContainer.innerHTML = `<div style="color: #856404; text-align: center;">${message}</div>`
+  ratingContainer.innerHTML = `<div class="bp-message">${message}</div>`
 }
 
 export function setRating(
@@ -74,95 +167,89 @@ export function setRating(
       ? generateStarsSvg(rating.rating)
       : generateCapSvg(rating.rating)
 
-  const ratingElement = document.createElement('div')
-  ratingElement.style.cssText = 'display: flex; align-items: center; gap: 5px;'
-  ratingElement.innerHTML = `
-        <strong>${i18n.t('rating')}:</strong>
-        ${svg}  (${rating.rating.toString()} ${i18n.t('of')} ${rating.votes.toString()} ${i18n.t('votes')})
+  const ratingRow = document.createElement('div')
+  ratingRow.className = 'bp-rating-row'
+  ratingRow.innerHTML = `
+        ${svg}
+        <span class="bp-score">${rating.rating.toString()}</span>
+        <span class="bp-scale">/ 5</span>
       `
 
-  const breweryElement = document.createElement('p')
+  const meta = document.createElement('div')
+  meta.className = 'bp-meta'
+  meta.innerText = `${rating.votes.toString()} ${i18n.t('votes')}`
   if (productType === ProductType.Beer) {
     const beerRating = rating as BeerResponse
-    breweryElement.innerText = `${i18n.t('brewery')}: ${beerRating.brewery ?? ''}`
-    breweryElement.style.cssText =
-      'color: #155724; margin: 0; line-height: 1.5;'
+    if (beerRating.brewery) {
+      meta.innerText += ` · ${beerRating.brewery}`
+    }
   }
 
-  const linkElement = document.createElement('a')
-  if (link) {
-    linkElement.href = link
-  }
-  linkElement.target = '_blank'
-  linkElement.rel = 'noopener noreferrer'
-  linkElement.style.cssText =
-    'color: #155724; text-decoration: underline; margin: 0; line-height: 1.5;'
+  const linkLabel =
+    productType === ProductType.Beer
+      ? i18n.t('linkToUntapped')
+      : i18n.t('linkToVivino')
 
-  switch (productType) {
-    case ProductType.Beer:
-      linkElement.innerText = i18n.t('linkToUntapped')
-      break
-    case ProductType.Wine:
-      linkElement.innerText = i18n.t('linkToVivino')
-      break
-  }
+  const footer = document.createElement('div')
+  footer.className = 'bp-footer'
+  footer.appendChild(meta)
+  footer.appendChild(createSourceLink(link, linkLabel))
 
-  const flexContainer = document.createElement('div')
-  flexContainer.style.cssText =
-    'display: flex; justify-content: space-between; align-items: center;'
-
-  const leftContainer = document.createElement('div')
-  leftContainer.appendChild(linkElement)
-
-  const rightContainer = document.createElement('div')
-  rightContainer.appendChild(breweryElement)
-
-  flexContainer.appendChild(leftContainer)
-  flexContainer.appendChild(rightContainer)
-
-  ratingContainer.appendChild(ratingElement)
-  ratingContainer.appendChild(flexContainer)
+  ratingContainer.appendChild(ratingRow)
+  ratingContainer.appendChild(footer)
 }
 
 export function setUncertain(productType: ProductType, link: null | string) {
   const ratingContainer = getAndClearContainer()
 
-  const ratingElement = document.createElement('div')
-  ratingElement.style.cssText = 'display: flex; align-items: center; gap: 5px;'
-  ratingContainer.innerHTML = `<div style="color: #856404; text-align: center;">${i18n.t('uncertainMatch')}</div>`
+  const message = document.createElement('div')
+  message.className = 'bp-message'
+  message.innerText = i18n.t('uncertainMatch')
 
-  const linkElement = document.createElement('a')
-  if (link) {
-    linkElement.href = link
-  }
-  linkElement.target = '_blank'
-  linkElement.rel = 'noopener noreferrer'
-  linkElement.style.cssText = 'color: #155724; text-decoration: underline;'
+  const linkLabel =
+    productType === ProductType.Beer
+      ? i18n.t('searchAtUntapped')
+      : i18n.t('searchAtVivino')
 
-  switch (productType) {
-    case ProductType.Beer:
-      linkElement.innerText = i18n.t('searchAtUntapped')
-      break
-    case ProductType.Wine:
-      linkElement.innerText = i18n.t('searchAtVivino')
-      break
-  }
+  const footer = document.createElement('div')
+  footer.className = 'bp-footer'
+  footer.style.justifyContent = 'center'
+  footer.style.marginTop = '6px'
+  footer.appendChild(createSourceLink(link, linkLabel))
 
-  ratingContainer.appendChild(ratingElement)
-  ratingContainer.appendChild(linkElement)
+  ratingContainer.appendChild(message)
+  ratingContainer.appendChild(footer)
 }
 
 export function showLoadingSpinner() {
   const ratingContainer = getAndClearContainer()
   const spinner = document.createElement('div')
-  spinner.style.cssText =
-    'display: flex; justify-content: center; align-items: center; height: 50px; gap: 10px;'
+  spinner.className = 'bp-spinner-wrap'
   spinner.innerHTML = `
-      <div class="spinner" style="border: 4px solid #f3f3f3; border-top: 4px solid #095741; border-radius: 50%; width: 30px; height: 30px; animation: spin 2s linear infinite;"></div>
-      <span style="font-size: 14px; color: #856404;">${i18n.t('loading')}..</span>
+      <div class="bp-spinner"></div>
+      <span class="bp-message">${i18n.t('loading')}</span>
     `
 
   ratingContainer.appendChild(spinner)
+}
+
+function createSourceLink(
+  link: null | string,
+  label: string
+): HTMLAnchorElement {
+  const linkElement = document.createElement('a')
+  linkElement.className = 'bp-link'
+  if (link) {
+    linkElement.href = link
+  }
+  linkElement.target = '_blank'
+  linkElement.rel = 'noopener noreferrer'
+  linkElement.append(label)
+  linkElement.insertAdjacentHTML(
+    'beforeend',
+    `<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7M9 7h8v8"/></svg>`
+  )
+  return linkElement
 }
 
 function generateCapSvg(rating: number): string {
@@ -181,15 +268,16 @@ function generateCapSvg(rating: number): string {
     if (rating >= i + 1) {
       capsHtml += capSvg(yellowCollor)
     } else if (rating >= i + 0.5) {
+      const gradientId = `bp-half-cap-${i.toString()}`
       capsHtml += `
       <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="${heightAndWidth}" height="${heightAndWidth}" viewBox="0 0 50 50" style="shape-rendering:geometricPrecision; text-rendering:geometricPrecision; image-rendering:optimizeQuality; fill-rule:evenodd; clip-rule:evenodd" xmlns:xlink="http://www.w3.org/1999/xlink">
         <defs>
-          <linearGradient id="halfStarGradient">
+          <linearGradient id="${gradientId}">
             <stop offset="50%" stop-color="${yellowCollor}" />
             <stop offset="50%" stop-color="${grayColor}" />
           </linearGradient>
         </defs>
-        <g><path style="opacity:0.954" fill="url(#halfStarGradient)" d="M 20.5,-0.5 C 22.1667,-0.5 23.8333,-0.5 25.5,-0.5C 25.8656,0.694594 26.699,1.36126 28,1.5C 31.7073,-0.156277 34.2073,1.01039 35.5,5C 39.7905,4.43599 41.9571,6.26933 42,10.5C 45.7611,11.7146 46.9277,14.048 45.5,17.5C 45.4534,19.0377 46.1201,20.0377 47.5,20.5C 47.5,21.8333 47.5,23.1667 47.5,24.5C 46.4749,25.3739 45.8082,26.5405 45.5,28C 47.1563,31.7073 45.9896,34.2073 42,35.5C 42.564,39.7905 40.7307,41.9571 36.5,42C 35.3336,45.5714 33.1669,46.7381 30,45.5C 28.3009,45.3866 27.1342,46.0532 26.5,47.5C 25.1667,47.5 23.8333,47.5 22.5,47.5C 21.6261,46.4749 20.4595,45.8082 19,45.5C 15.2927,47.1563 12.7927,45.9896 11.5,42C 7.20953,42.564 5.04286,40.7307 5,36.5C 1.42855,35.3336 0.261888,33.1669 1.5,30C 1.61345,28.3009 0.94678,27.1342 -0.5,26.5C -0.5,25.1667 -0.5,23.8333 -0.5,22.5C 0.525111,21.6261 1.19178,20.4595 1.5,19C -0.156277,15.2927 1.01039,12.7927 5,11.5C 4.43599,7.20953 6.26933,5.04286 10.5,5C 11.6664,1.42855 13.8331,0.261888 17,1.5C 18.6991,1.61345 19.8658,0.94678 20.5,-0.5 Z"/></g>
+        <g><path style="opacity:0.954" fill="url(#${gradientId})" d="M 20.5,-0.5 C 22.1667,-0.5 23.8333,-0.5 25.5,-0.5C 25.8656,0.694594 26.699,1.36126 28,1.5C 31.7073,-0.156277 34.2073,1.01039 35.5,5C 39.7905,4.43599 41.9571,6.26933 42,10.5C 45.7611,11.7146 46.9277,14.048 45.5,17.5C 45.4534,19.0377 46.1201,20.0377 47.5,20.5C 47.5,21.8333 47.5,23.1667 47.5,24.5C 46.4749,25.3739 45.8082,26.5405 45.5,28C 47.1563,31.7073 45.9896,34.2073 42,35.5C 42.564,39.7905 40.7307,41.9571 36.5,42C 35.3336,45.5714 33.1669,46.7381 30,45.5C 28.3009,45.3866 27.1342,46.0532 26.5,47.5C 25.1667,47.5 23.8333,47.5 22.5,47.5C 21.6261,46.4749 20.4595,45.8082 19,45.5C 15.2927,47.1563 12.7927,45.9896 11.5,42C 7.20953,42.564 5.04286,40.7307 5,36.5C 1.42855,35.3336 0.261888,33.1669 1.5,30C 1.61345,28.3009 0.94678,27.1342 -0.5,26.5C -0.5,25.1667 -0.5,23.8333 -0.5,22.5C 0.525111,21.6261 1.19178,20.4595 1.5,19C -0.156277,15.2927 1.01039,12.7927 5,11.5C 4.43599,7.20953 6.26933,5.04286 10.5,5C 11.6664,1.42855 13.8331,0.261888 17,1.5C 18.6991,1.61345 19.8658,0.94678 20.5,-0.5 Z"/></g>
       </svg>`
     } else {
       capsHtml += capSvg(grayColor)
@@ -217,15 +305,16 @@ function generateStarsSvg(rating: number): string {
       starsHtml += starSvg(redColor)
     } else if (rating >= i + 0.5) {
       // Half red star using linear gradient
+      const gradientId = `bp-half-star-${i.toString()}`
       starsHtml += `
           <svg width="20" height="20" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <defs>
-              <linearGradient id="halfStarGradient">
+              <linearGradient id="${gradientId}">
                 <stop offset="50%" stop-color="${redColor}" />
                 <stop offset="50%" stop-color="${grayColor}" />
               </linearGradient>
             </defs>
-            <path d="M12 .587l3.668 7.568L24 9.423l-6 5.832 1.416 8.25L12 18.897 4.584 23.505 6 15.255l-6-5.832 8.332-1.268L12 .587z" fill="url(#halfStarGradient)"/>
+            <path d="M12 .587l3.668 7.568L24 9.423l-6 5.832 1.416 8.25L12 18.897 4.584 23.505 6 15.255l-6-5.832 8.332-1.268L12 .587z" fill="url(#${gradientId})"/>
           </svg>`
     } else {
       // Empty gray star

--- a/src/components/github.ts
+++ b/src/components/github.ts
@@ -1,5 +1,7 @@
-// Should be set dynamically? Or should it be retrieved from manifest.json/package.json?
-export const version = '1.0.0'
+import browser from 'webextension-polyfill'
+
+// Sourced from the manifest, which WXT generates from package.json's version.
+export const version = browser.runtime.getManifest().version
 
 // TODO: Wip
 interface GitHubRelease {

--- a/src/components/productUtils.ts
+++ b/src/components/productUtils.ts
@@ -35,14 +35,59 @@ export function getProductType(): ProductType {
   return ProductType.Uncertain
 }
 
+// Wine formats that are not a bottle and have no comparable Vivino rating.
+// We exclude these rather than allow-list bottle types, so bottle variants
+// (Flaska, Magnum, Halvflaska, …) all pass without enumerating them.
+const NON_BOTTLE_FORMATS = [
+  'box',
+  'bag-in-box',
+  'burk',
+  'pet',
+  'tetra',
+  'påse',
+  'pappförpackning',
+  'fat',
+  'pouch'
+]
+
 export function isBottle(): boolean {
   const main = document.querySelector('main')
   if (main == null) {
-    return false
+    return true
   }
 
-  const BOTTLE_STRING = 'flaska'
-  return Array.from(main.querySelectorAll('span, option')).some((el) =>
-    el.textContent.toLowerCase().includes(BOTTLE_STRING)
+  const descriptor = getPackagingDescriptor(main)
+  // If we can't read the format line, assume bottle rather than block the rating.
+  if (!descriptor) {
+    return true
+  }
+
+  return !NON_BOTTLE_FORMATS.some((format) => descriptor.includes(format))
+}
+
+// Reads the packaging type from the format line under the product title, which
+// reads "{packaging} · {volume} · {alcohol} % vol." — e.g. "Flaska", "Magnum",
+// "Bag-in-Box". Anchored on the alcohol content, which is always present.
+function getPackagingDescriptor(main: HTMLElement): null | string {
+  const volumeLeaf = Array.from(main.querySelectorAll('*')).find(
+    (el) => el.children.length === 0 && /%\s*vol\.?/i.test(el.textContent)
   )
+  if (!volumeLeaf) {
+    return null
+  }
+
+  let node: HTMLElement | null = volumeLeaf as HTMLElement
+  for (let i = 0; i < 4 && node; i++) {
+    const text = node.textContent
+    if (/[·•]/.test(text) && /\d/.test(text) && text.length < 80) {
+      break
+    }
+    node = node.parentElement
+  }
+  if (!node) {
+    return null
+  }
+
+  const firstSegment = node.textContent.split(/[·•]/)[0].trim().toLowerCase()
+  return firstSegment ? firstSegment : null
 }

--- a/src/entrypoints/popup/main.ts
+++ b/src/entrypoints/popup/main.ts
@@ -9,7 +9,8 @@ async function checkForUpdate(
   installUpdateButton: HTMLButtonElement
 ): Promise<void> {
   const release = await getLatestRelease()
-  if (release && version !== release.tag_name) {
+  const latest = release?.tag_name.replace(/^v/, '')
+  if (release && latest !== version) {
     installUpdateButton.disabled = false
     installUpdateButton.addEventListener('click', () => {
       window.open(release.html_url, '_blank')
@@ -18,6 +19,7 @@ async function checkForUpdate(
 }
 
 async function initialize(): Promise<void> {
+  showVersion()
   await setupToggles()
 
   const shareButton = document.getElementById('shareButton')
@@ -60,6 +62,13 @@ async function shareExtension(): Promise<void> {
   } catch {
     //eslint-disable-next-line no-console
     console.error('Failed to copy extension URL to clipboard')
+  }
+}
+
+function showVersion(): void {
+  const versionLabel = document.querySelector('.version')
+  if (versionLabel) {
+    versionLabel.textContent = `v${version}`
   }
 }
 

--- a/src/entrypoints/popup/style.css
+++ b/src/entrypoints/popup/style.css
@@ -15,7 +15,13 @@ html {
 .gradient-bg {
   position: absolute;
   inset: 0;
-  background: #18181a;
+  background:
+    radial-gradient(
+      120% 80% at 100% 0%,
+      rgba(9, 87, 65, 0.35) 0%,
+      transparent 55%
+    ),
+    #18181a;
 }
 .content {
   position: relative;
@@ -25,7 +31,6 @@ html {
   padding: 16px;
   background-color: rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(4px);
-  /* T */
   box-sizing: border-box;
 }
 .top-bar {


### PR DESCRIPTION
## Summary

Three changes on this branch: a redesigned rating card (the headline), a fix for a bottle-detection bug that hid ratings on legitimate bottles, and a popup version fix.

## Rating card (`domUtils.ts`)
- Replaces the yellow "warning banner" look with a branded card — green ◆ Bolaget+ header, a single green accent, page-inherited font, on a light surface that matches Systembolaget's own design.
- All inline styles moved into one injected stylesheet; faster spinner.
- Half-star/cap gradients now use unique IDs (duplicate `id`s were invalid HTML).

## Bottle detection (`productUtils.ts`)
`isBottle()` searched for the literal word **"flaska"**, which:
1. wrongly rejected real bottles labelled **Magnum / Halvflaska / etc.** (a Magnum says "Magnum", not "Flaska"), and
2. only ever matched the sustainability boilerplate that appears on *every* product — so it couldn't actually distinguish a box from a bottle.

It now reads the packaging token from the format line under the title (`{packaging} · {volume} · {alcohol} % vol.`) and treats it as a bottle **unless** the token matches a non-bottle blocklist (`box`, `bag-in-box`, `burk`, `pet`, `tetra`, …). Falls back to "is a bottle" when the line can't be read, so ratings are never silently blocked.

**Repro:** https://www.systembolaget.se/produkt/vin/black-stallion-7252406/ (a Magnum) previously showed "Vinet är inte på flaska"; it now shows the rating.

## Popup (`main.ts`, `style.css`)
- Fixes the stale hardcoded version — now sourced from the manifest and rendered into the footer.
- Update check tolerates a `v` prefix on the GitHub release tag.
- `.gradient-bg` is now an actual gradient; removed a leftover comment.

## Verification
- `pnpm compile`, `pnpm lint`, `pnpm build:chrome` all clean.
- Full e2e suite (4 tests) passes. Updated e2e selectors for the redesign (`.spinner` → `.bp-spinner`; star count scoped to `.bp-rating-row` now that the source link carries an arrow icon).
- Verified the redesigned card renders on the Magnum page (loaded the built extension via Playwright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)