### PR TITLE
fix: include vintage year in Vivino query and always show search link on no match

### DIFF
--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -102,14 +102,20 @@ export async function fetchRatingFromVivino(
     })
 
     if (!response.ok) {
-      return { status: RatingResultStatus.NotFound } as RatingResponse
+      return {
+        link: searchFallbackUrl,
+        status: RatingResultStatus.Uncertain
+      } as RatingResponse
     }
 
     const data = (await response.json()) as VivinoReponseJSON
     const matches = data.explore_vintage?.matches ?? []
 
     if (matches.length === 0) {
-      return { status: RatingResultStatus.NotFound } as RatingResponse
+      return {
+        link: searchFallbackUrl,
+        status: RatingResultStatus.Uncertain
+      } as RatingResponse
     }
 
     type ScoredWine = RatingResponse & { similarityRate: number }
@@ -153,6 +159,9 @@ export async function fetchRatingFromVivino(
 
     return bestMatch
   } catch {
-    return { status: RatingResultStatus.NotFound } as RatingResponse
+    return {
+      link: searchFallbackUrl,
+      status: RatingResultStatus.Uncertain
+    } as RatingResponse
   }
 }

--- a/src/components/productUtils.ts
+++ b/src/components/productUtils.ts
@@ -15,11 +15,11 @@ export function getProductName(): null | string {
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const secondLine = (headerChildren[1] as HTMLElement).innerText.trim() ?? ''
-  const secondLineWithoutComma = secondLine.includes(',')
-    ? secondLine.slice(0, secondLine.lastIndexOf(',')).trim()
-    : secondLine
+  // Replace ", " separator with a space so "Cabernet Sauvignon, 2025" → "Cabernet Sauvignon 2025".
+  // The vintage year is important for Vivino's per-vintage search index.
+  const secondLineNormalized = secondLine.replace(/,\s*/, ' ').trim()
 
-  return `${firstLine} ${secondLineWithoutComma}`.trim()
+  return `${firstLine} ${secondLineNormalized}`.trim()
 }
 
 export function getProductType(): ProductType {


### PR DESCRIPTION
## Summary

- **Include vintage year in search query**: The second h1 line on Systembolaget product pages is formatted as `"{grape}, {year}"` (e.g. `"Cabernet Sauvignon, 2025"`). Previously the year was stripped; now `", "` is replaced with a space so the full `"Cabernet Sauvignon 2025"` is sent to Vivino, which organises results by vintage.
- **Always provide a Vivino search link on failure**: All failure paths in `fetchRatingFromVivino` (no results, non-OK response, exception) now return `Uncertain` with a Vivino search URL instead of a hard `NotFound`. Users who visit a page for a wine not indexed on Vivino will get a clickable link to search manually rather than a dead-end error message.

## Test plan

- [ ] Visit a wine page with a known Vivino entry — rating should still display correctly
- [ ] Visit a wine page not on Vivino (e.g. [Moonlight Manor](https://www.systembolaget.se/produkt/vin/moonlight-manor-471501/) or [Torre do Olivar](https://www.systembolaget.se/produkt/vin/torre-do-olivar-282001/)) — should now show the "uncertain" state with a Vivino search link instead of "Tyvärr, vi kunde inte hitta något betyg för denna produkt."

🤖 Generated with [Claude Code](https://claude.com/claude-code)