### PR TITLE
feat: show ratings on product list pages

### DIFF
--- a/e2e/end-to-end.spec.ts
+++ b/e2e/end-to-end.spec.ts
@@ -106,3 +106,21 @@ test('visiting a wine page shows rating-container with ratings and stars', async
   const vivinoLink = ratingContainer.locator('a[href*="vivino.com"]');
   await expect(vivinoLink).toBeVisible();
 });
+
+test('visiting wine list page shows rating badges on product cards', async ({
+  page,
+  extensionId
+}) => {
+  await page.goto(`chrome-extension://${extensionId}/popup.html`)
+  await page.waitForSelector('.settings')
+  await expect(page.locator('#enabled')).toBeChecked()
+  await expect(page.locator('#wine')).toBeChecked()
+
+  await page.goto('https://www.systembolaget.se/sortiment/vin/')
+  await page.getByRole('link', { name: 'Jag har fyllt 20 år' }).click()
+  await page.getByRole('button', { name: 'Acceptera alla kakor' }).click()
+  await page.reload()
+
+  await page.waitForSelector('.bp-card-rating', { timeout: 20000 })
+  await expect(page.locator('.bp-card-rating').first()).toBeVisible()
+})

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -15,6 +15,7 @@ export type BeerResponse = RatingResponse & {
 }
 
 export interface RatingRequest {
+  productId: string
   productName: string
   query: ProductType
 }

--- a/src/components/domUtils.ts
+++ b/src/components/domUtils.ts
@@ -1,6 +1,11 @@
 import { i18n } from '#i18n'
 
-import { BeerResponse, ProductType, RatingResponse } from '@/@types/types'
+import {
+  BeerResponse,
+  ProductType,
+  RatingResponse,
+  RatingResultStatus
+} from '@/@types/types'
 
 const RATING_CONTAINER_ID = 'rating-container'
 const RATING_CONTAINER_BODY_ID = 'rating-container-body'
@@ -102,6 +107,32 @@ const STYLES = `
   @keyframes bp-spin {
     to { transform: rotate(360deg); }
   }
+  .bp-card-rating {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 4px;
+  }
+  .bp-card-rating svg { width: 14px; height: 14px; }
+  .bp-card-rating .bp-card-score {
+    font-weight: 700;
+    font-size: 12px;
+    color: #1a1a1a;
+  }
+  .bp-card-rating .bp-card-votes {
+    color: #888;
+    font-size: 11px;
+  }
+  .bp-card-spinner-inline {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    margin-top: 6px;
+    border: 2px solid #e8e8e8;
+    border-top-color: #095741;
+    border-radius: 50%;
+    animation: bp-spin 0.8s linear infinite;
+  }
 `
 
 export function getAndClearContainer(): HTMLElement {
@@ -139,12 +170,7 @@ export function injectRatingContainer() {
     )
   }
 
-  if (!document.getElementById(STYLE_ID)) {
-    const style = document.createElement('style')
-    style.id = STYLE_ID
-    style.textContent = STYLES
-    document.head.appendChild(style)
-  }
+  ensureStyles()
 }
 
 export function setMessage(message: string) {
@@ -252,6 +278,14 @@ function createSourceLink(
   return linkElement
 }
 
+function ensureStyles(): void {
+  if (document.getElementById(STYLE_ID)) return
+  const style = document.createElement('style')
+  style.id = STYLE_ID
+  style.textContent = STYLES
+  document.head.appendChild(style)
+}
+
 function generateCapSvg(rating: number): string {
   const maxCaps = 5
   const yellowCollor = '#ffc000'
@@ -285,6 +319,45 @@ function generateCapSvg(rating: number): string {
   }
 
   return `<div style="display: flex">${capsHtml}</div>`
+}
+
+const CARD_RATING_CLASS = 'bp-card-rating'
+
+export function injectCardSpinner(card: Element): HTMLElement | null {
+  if (card.querySelector(`.${CARD_RATING_CLASS}, .bp-card-spinner-inline`)) {
+    return null
+  }
+  ensureStyles()
+  const lastNameSpan = [...card.querySelectorAll('.monopol-250')].at(-1)
+  if (!lastNameSpan) return null
+
+  const spinner = document.createElement('div')
+  spinner.className = 'bp-card-spinner-inline'
+  lastNameSpan.insertAdjacentElement('afterend', spinner)
+  return spinner
+}
+
+export function replaceCardSpinner(
+  spinner: HTMLElement,
+  productType: ProductType,
+  rating: RatingResponse
+): void {
+  if (rating.status !== RatingResultStatus.Found) {
+    spinner.remove()
+    return
+  }
+  const svg =
+    productType === ProductType.Wine
+      ? generateStarsSvg(rating.rating)
+      : generateCapSvg(rating.rating)
+  const badge = document.createElement('div')
+  badge.className = CARD_RATING_CLASS
+  badge.innerHTML = `
+    ${svg}
+    <span class="bp-card-score">${rating.rating.toString()}</span>
+    <span class="bp-card-votes">(${rating.votes.toString()})</span>
+  `
+  spinner.replaceWith(badge)
 }
 
 function generateStarsSvg(rating: number): string {

--- a/src/components/productUtils.ts
+++ b/src/components/productUtils.ts
@@ -1,5 +1,33 @@
 import { ProductType } from '@/@types/types'
 
+export function getCardName(card: Element): null | string {
+  const spans = [...card.querySelectorAll('.monopol-250')] as HTMLElement[]
+  if (spans.length === 0) return null
+  const parts = spans.map((s) => s.innerText.trim()).filter(Boolean)
+  // Normalize ", 2025" → " 2025" so vintage year is included without comma
+  return (
+    parts
+      .join(' ')
+      .replace(/,\s*(\d{4})/, ' $1')
+      .trim() || null
+  )
+}
+
+export function getCardProductId(card: Element): null | string {
+  return extractProductId(card.getAttribute('href') ?? '')
+}
+
+export function getCardProductType(card: Element): ProductType {
+  const href = card.getAttribute('href') ?? ''
+  if (href.includes('/produkt/vin/')) return ProductType.Wine
+  if (href.includes('/produkt/ol/')) return ProductType.Beer
+  return ProductType.Uncertain
+}
+
+export function getProductId(): null | string {
+  return extractProductId(window.location.href)
+}
+
 export function getProductName(): null | string {
   const headerChildren = document.querySelector('main h1')?.children
 
@@ -63,6 +91,14 @@ export function isBottle(): boolean {
   }
 
   return !NON_BOTTLE_FORMATS.some((format) => descriptor.includes(format))
+}
+
+export function isListPage(): boolean {
+  return window.location.pathname.includes('/sortiment/')
+}
+
+function extractProductId(url: string): null | string {
+  return /\/(\d+)\/?$/.exec(url)?.[1] ?? null
 }
 
 // Reads the packaging type from the format line under the product title, which

--- a/src/components/ratingService.ts
+++ b/src/components/ratingService.ts
@@ -10,11 +10,12 @@ import {
 import { saveRating as cacheRating, tryGetRating } from './ratingsCache'
 
 export async function fetchRating(
+  productId: string,
   productName: string,
   type: ProductType
 ): Promise<RatingResponse> {
   try {
-    const ratingRequest = { productName, query: type }
+    const ratingRequest = { productId, productName, query: type }
     const cachedRating = await tryGetRating(ratingRequest)
     if (cachedRating) {
       return cachedRating
@@ -31,4 +32,25 @@ export async function fetchRating(
   } catch {
     return { status: RatingResultStatus.NotFound } as RatingResponse
   }
+}
+
+const LIST_FETCH_DELAY_MS = 300
+
+let listFetchQueue: Promise<undefined> = Promise.resolve(undefined)
+
+export function enqueueListFetch(
+  productId: string,
+  productName: string,
+  type: ProductType
+): Promise<RatingResponse> {
+  const task = listFetchQueue.then(
+    () =>
+      new Promise<RatingResponse>((resolve) => {
+        setTimeout(() => {
+          void fetchRating(productId, productName, type).then(resolve)
+        }, LIST_FETCH_DELAY_MS)
+      })
+  )
+  listFetchQueue = task.then(() => undefined)
+  return task
 }

--- a/src/components/ratingsCache.ts
+++ b/src/components/ratingsCache.ts
@@ -49,5 +49,5 @@ function calculateDaysDifference(date1: Date, date2: Date): number {
 }
 
 function generateCacheKey(ratingRequest: RatingRequest): `local:${string}` {
-  return `local:ratings:${ratingRequest.productName}-${ratingRequest.query}`
+  return `local:ratings:${ratingRequest.productId}-${ratingRequest.query}`
 }

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -7,14 +7,28 @@ import {
 } from '@/@types/types'
 import * as domUtils from '@/components/domUtils'
 import * as productUtils from '@/components/productUtils'
-import { fetchRating } from '@/components/ratingService'
+import { enqueueListFetch, fetchRating } from '@/components/ratingService'
 import { wineFeatureEnabled } from '@/components/settings'
 
 export default defineContentScript({
   main() {
+    const listCardObserver = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue
+          listCardObserver.unobserve(entry.target)
+          void handleListCard(entry.target)
+        }
+      },
+      { rootMargin: '200px' }
+    )
+
     //eslint-disable-next-line @typescript-eslint/no-misused-promises
     sentinel.on('h1', tryInsertOnProdcutPage)
     void tryInsertOnProdcutPage()
+    sentinel.on('a[id^="tile:"]', (card) => {
+      listCardObserver.observe(card)
+    })
   },
   matches: ['*://*.systembolaget.se/*']
 })
@@ -30,6 +44,32 @@ async function featureEnabled(productType: ProductType): Promise<boolean> {
     return false
   }
   return true
+}
+
+async function handleListCard(card: Element) {
+  if (!(await featuresEnabled.getValue())) return
+  const productType = productUtils.getCardProductType(card)
+  if (productType === ProductType.Uncertain) return
+  if (
+    productType === ProductType.Wine &&
+    !(await wineFeatureEnabled.getValue())
+  )
+    return
+  if (
+    productType === ProductType.Beer &&
+    !(await beerFeatureEnabled.getValue())
+  )
+    return
+
+  const productId = productUtils.getCardProductId(card)
+  const name = productUtils.getCardName(card)
+  if (!productId || !name) return
+
+  const spinner = domUtils.injectCardSpinner(card)
+  if (!spinner) return
+
+  const rating = await enqueueListFetch(productId, name, productType)
+  domUtils.replaceCardSpinner(spinner, productType, rating)
 }
 
 function handleRating(productType: ProductType, rating: RatingResponse) {
@@ -64,8 +104,9 @@ async function tryInsertOnProdcutPage() {
     return
   }
 
+  const productId = productUtils.getProductId()
   const productName = productUtils.getProductName()
-  if (!productName) {
+  if (!productId || !productName) {
     return
   }
 
@@ -73,7 +114,7 @@ async function tryInsertOnProdcutPage() {
     fetchingRatingInProgress = true
     domUtils.showLoadingSpinner()
 
-    const rating = await fetchRating(productName, productType)
+    const rating = await fetchRating(productId, productName, productType)
     handleRating(productType, rating)
   } catch {
     domUtils.setMessage(i18n.t('noMatch'))


### PR DESCRIPTION
## Summary

- Injects compact star/cap rating badges on `/sortiment/` list and search pages
- Uses `IntersectionObserver` so only cards visible in the viewport trigger requests (~6 per load, not all 30)
- Sequential 300 ms queue in `ratingService` serialises requests to avoid rate limiting from Vivino/Untappd
- Cache key now uses the Systembolaget product ID (from URL) instead of product name, ensuring reliable cache hits between list and product pages

## Changes

- `productUtils.ts` — `getCardName`, `getCardProductId`, `getCardProductType`, `getProductId`, `isListPage` helpers
- `ratingService.ts` — `enqueueListFetch` sequential queue; `fetchRating` now takes `productId`
- `ratingsCache.ts` — cache key uses `productId` instead of `productName`
- `domUtils.ts` — `injectCardSpinner`, `replaceCardSpinner`, compact badge CSS
- `content.ts` — `IntersectionObserver` + `sentinel.on('a[id^="tile:"]', …)` wiring
- `types.ts` — `productId` field on `RatingRequest`
- `e2e/end-to-end.spec.ts` — list page badge test

Closes #2

## Test plan

- [ ] Browse `/sortiment/vin/` — badges appear on visible cards; off-screen cards have no spinner
- [ ] Scroll down — new cards get badges as they enter viewport
- [ ] Toggle wine/beer off in popup — badges stop appearing on list pages
- [ ] Visit a single product page — existing Bolaget+ card still works
- [ ] Revisit a list page after visiting the same product page — instant load from cache (no network request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)