### PR TITLE
fix: recover catalogue-only wines Vivino explore API misses

### DIFF
--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -15,11 +15,73 @@ test.describe('API Integration Tests', () => {
 
   test('fetchRatingFromUntappd returns data for valid query', async () => {
     const result = await fetchRatingFromUntappd('Pabst Blue Ribbon');
-    
+
     expect(result).not.toBeNull();
     expect(result?.status).toBe(RatingResultStatus.Found);
     expect(result?.rating).toBeGreaterThan(0);
     expect(result?.votes).toBeGreaterThan(0);
     expect(result?.link).toContain('untappd.com');
+  });
+});
+
+// Offline tests for the Vivino search-page fallback. The explore API only
+// indexes marketplace wines, so catalogue-only wines (e.g. Torre do Olivar)
+// come back empty there and must be recovered by scraping the web search.
+test.describe('Vivino search-page fallback (mocked fetch)', () => {
+  const realFetch = globalThis.fetch;
+
+  test.afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  function mockFetch(handler: (url: string) => { body: string; ok?: boolean }) {
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const { body, ok = true } = handler(url);
+      return Promise.resolve({
+        ok,
+        json: () => Promise.resolve(JSON.parse(body)),
+        text: () => Promise.resolve(body),
+      } as Response);
+    }) as typeof fetch;
+  }
+
+  test('recovers a catalogue-only wine from the search page when the explore API is empty', async () => {
+    mockFetch((url) => {
+      if (url.includes('/api/explore/explore')) {
+        return { body: JSON.stringify({ explore_vintage: { matches: [] } }) };
+      }
+      return {
+        body: `
+          <div class="default-wine-card">
+            <a href="/w/172616684">link</a>
+            <span class="wine-card__name">Torre do Olivar</span>
+            <div class="average__number">4,2</div>
+            <div class="average__stars"><span class="text-micro">1 234 ratings</span></div>
+          </div>`,
+      };
+    });
+
+    const result = await fetchRatingFromVivino('Torre do Olivar');
+
+    expect(result.status).toBe(RatingResultStatus.Found);
+    expect(result.rating).toBeCloseTo(4.2);
+    expect(result.votes).toBe(1234);
+    expect(result.link).toBe('https://www.vivino.com/w/172616684');
+  });
+
+  test('returns Uncertain with a search link (not NotFound) when nothing is found anywhere', async () => {
+    mockFetch((url) => {
+      if (url.includes('/api/explore/explore')) {
+        return { body: JSON.stringify({ explore_vintage: { matches: [] } }) };
+      }
+      return { body: '<div class="no-results"></div>' };
+    });
+
+    const result = await fetchRatingFromVivino('Some Obscure Wine');
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.link).toContain('vivino.com/search/wines');
+    expect(result.link).toContain('Some%20Obscure%20Wine');
   });
 });

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -76,9 +76,52 @@ export async function fetchRatingFromUntappd(
   }
 }
 
+const VIVINO_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36'
+
 export async function fetchRatingFromVivino(
   query: string
 ): Promise<RatingResponse> {
+  const searchFallbackUrl = `https://www.vivino.com/search/wines?q=${encodeURIComponent(
+    query
+  )}`
+
+  try {
+    // The explore API is fast and structured, but only indexes wines in
+    // Vivino's marketplace — it misses catalogue-only wines that have a
+    // ratings page yet aren't listed for sale.
+    const apiMatch = await searchVivinoExploreApi(query)
+    if (apiMatch) {
+      return apiMatch
+    }
+
+    // Fall back to scraping the public web search, which lists catalogue-only
+    // wines the explore API skips.
+    const scrapedMatch = await searchVivinoSearchPage(query)
+    if (scrapedMatch) {
+      return scrapedMatch
+    }
+
+    // Nothing solid found — hand the user a working Vivino search link rather
+    // than a dead-end "no rating" message.
+    return {
+      link: searchFallbackUrl,
+      status: RatingResultStatus.Uncertain
+    } as RatingResponse
+  } catch {
+    return {
+      link: searchFallbackUrl,
+      status: RatingResultStatus.Uncertain
+    } as RatingResponse
+  }
+}
+
+// Queries Vivino's marketplace explore API and returns the best confident
+// match, or null when nothing usable is found (no matches, low similarity,
+// missing rating, or a non-OK response).
+async function searchVivinoExploreApi(
+  query: string
+): Promise<null | RatingResponse> {
   const params = new URLSearchParams({
     facets: 'false',
     language: 'en',
@@ -89,70 +132,134 @@ export async function fetchRatingFromVivino(
     search_term: query
   })
   const url = `https://www.vivino.com/api/explore/explore?${params.toString()}`
-  const searchFallbackUrl = `https://www.vivino.com/search/wines?q=${encodeURIComponent(query)}`
 
-  try {
-    const response = await fetch(url, {
-      credentials: 'include',
-      headers: {
-        Accept: 'application/json',
-        'User-Agent':
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36'
-      }
-    })
-
-    if (!response.ok) {
-      return { status: RatingResultStatus.NotFound } as RatingResponse
+  const response = await fetch(url, {
+    credentials: 'include',
+    headers: {
+      Accept: 'application/json',
+      'User-Agent': VIVINO_USER_AGENT
     }
+  })
 
-    const data = (await response.json()) as VivinoReponseJSON
-    const matches = data.explore_vintage?.matches ?? []
-
-    if (matches.length === 0) {
-      return { status: RatingResultStatus.NotFound } as RatingResponse
-    }
-
-    type ScoredWine = RatingResponse & { similarityRate: number }
-
-    const bestMatch = matches.reduce<null | ScoredWine>(
-      (best, match: VivinoMatch) => {
-        const wineName = match.vintage.name
-        const rating = match.vintage.statistics.ratings_average ?? -1
-        const votes = match.vintage.statistics.ratings_count ?? -1
-        const link = `https://www.vivino.com/wines/${match.vintage.wine.id.toString()}`
-        const similarityRate = stringSimilarity.compareTwoStrings(
-          query,
-          wineName
-        )
-
-        const current: ScoredWine = {
-          link,
-          name: wineName,
-          rating,
-          similarityRate,
-          status: RatingResultStatus.Found,
-          votes
-        }
-
-        return similarityRate > (best?.similarityRate ?? 0) ? current : best
-      },
-      null
-    )
-
-    if (
-      !bestMatch ||
-      bestMatch.similarityRate < 0.5 ||
-      bestMatch.rating < 0 ||
-      bestMatch.votes < 0
-    ) {
-      return {
-        link: searchFallbackUrl,
-        status: RatingResultStatus.Uncertain
-      } as RatingResponse
-    }
-
-    return bestMatch
-  } catch {
-    return { status: RatingResultStatus.NotFound } as RatingResponse
+  if (!response.ok) {
+    return null
   }
+
+  const data = (await response.json()) as VivinoReponseJSON
+  const matches = data.explore_vintage?.matches ?? []
+
+  if (matches.length === 0) {
+    return null
+  }
+
+  type ScoredWine = RatingResponse & { similarityRate: number }
+
+  const bestMatch = matches.reduce<null | ScoredWine>(
+    (best, match: VivinoMatch) => {
+      const wineName = match.vintage.name
+      const rating = match.vintage.statistics.ratings_average ?? -1
+      const votes = match.vintage.statistics.ratings_count ?? -1
+      const link = `https://www.vivino.com/wines/${match.vintage.wine.id.toString()}`
+      const similarityRate = stringSimilarity.compareTwoStrings(query, wineName)
+
+      const current: ScoredWine = {
+        link,
+        name: wineName,
+        rating,
+        similarityRate,
+        status: RatingResultStatus.Found,
+        votes
+      }
+
+      return similarityRate > (best?.similarityRate ?? 0) ? current : best
+    },
+    null
+  )
+
+  if (
+    !bestMatch ||
+    bestMatch.similarityRate < 0.5 ||
+    bestMatch.rating < 0 ||
+    bestMatch.votes < 0
+  ) {
+    return null
+  }
+
+  return bestMatch
+}
+
+// Scrapes Vivino's public web search results, which surface catalogue-only
+// wines missing from the explore API. Returns a Found match when a confident,
+// rated wine card is parsed; an Uncertain deep-link when a plausible wine card
+// is found without a trustworthy rating; or null when nothing is found.
+async function searchVivinoSearchPage(
+  query: string
+): Promise<null | RatingResponse> {
+  const url = `https://www.vivino.com/search/wines?q=${encodeURIComponent(
+    query
+  )}`
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'text/html',
+      'User-Agent': VIVINO_USER_AGENT
+    }
+  })
+
+  if (!response.ok) {
+    return null
+  }
+
+  const $ = cheerio.load(await response.text())
+  const card = $('.default-wine-card, .wine-card').first()
+  if (card.length === 0) {
+    return null
+  }
+
+  const href =
+    card.find('a[href*="/w/"], a[href*="/wines/"]').first().attr('href') ?? ''
+  if (!href) {
+    return null
+  }
+  const link = new URL(href, 'https://www.vivino.com').toString()
+
+  const name = card
+    .find('.wine-card__name, .header-smaller')
+    .first()
+    .text()
+    .trim()
+  const similarityRate = stringSimilarity.compareTwoStrings(query, name)
+
+  const rating = parseFloat(
+    card.find('.average__number').first().text().trim().replace(',', '.')
+  )
+  const votes = parseInt(
+    card
+      .find('.average__stars .text-micro, .text-micro')
+      .first()
+      .text()
+      .replace(/[^0-9]/g, ''),
+    10
+  )
+
+  const hasConfidentName = name.length > 0 && similarityRate >= 0.5
+  const hasRating =
+    Number.isFinite(rating) && rating > 0 && Number.isFinite(votes) && votes > 0
+
+  if (hasConfidentName && hasRating) {
+    return {
+      link,
+      name,
+      rating,
+      status: RatingResultStatus.Found,
+      votes
+    }
+  }
+
+  // We found a plausible wine page but couldn't confirm a trustworthy rating —
+  // deep-link the wine so the user can check it directly.
+  return {
+    link,
+    status: RatingResultStatus.Uncertain
+  } as RatingResponse
 }


### PR DESCRIPTION
The Vivino lookup only queried the marketplace `explore/explore` endpoint,
which indexes wines available for sale — not Vivino's full ratings catalogue.
Wines with a ratings page but no marketplace listing (e.g. Torre do Olivar)
returned zero matches and surfaced the bare "no rating" dead end, even though
the wine is findable on vivino.com.

- Add a web-search scrape fallback (`/search/wines`) that runs when the
  explore API returns nothing usable, recovering catalogue-only wines.
- On zero/failed lookups, return Uncertain with a working Vivino search link
  instead of NotFound, so the user always gets a way forward rather than a
  dead end.
- Split the Vivino logic into `searchVivinoExploreApi` and
  `searchVivinoSearchPage` helpers behind the `fetchRatingFromVivino`
  orchestrator.
- Add offline (mocked-fetch) tests covering the fallback and the
  no-match-anywhere path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Sq6iP15EL5kPuBJPNJ1DZD