### PR TITLE
feat: switch Untappd lookup to Algolia search API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ web-ext.config.ts
 # playwright
 playwright-report/
 test-results/.last-run.json
+
+# Local tool artifacts
+.playwright-mcp/
+.spec-workflow/

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "@wxt-dev/i18n": "^0.2.5",
     "@wxt-dev/storage": "^1.2.8",
-    "cheerio": "^1.2.0",
     "sentinel-js": "^0.0.7",
     "string-similarity": "^4.0.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@wxt-dev/storage':
         specifier: ^1.2.8
         version: 1.2.8
-      cheerio:
-        specifier: ^1.2.0
-        version: 1.2.0
       sentinel-js:
         specifier: ^0.0.7
         version: 0.0.7
@@ -1202,13 +1199,6 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
-  cheerio-select@2.1.0:
-    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
-
-  cheerio@1.2.0:
-    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
-    engines: {node: '>=20.18.1'}
-
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
@@ -1393,15 +1383,8 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
-  encoding-sniffer@0.2.1:
-    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
-
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
-    engines: {node: '>=0.12'}
-
-  entities@6.0.1:
-    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   entities@7.0.1:
@@ -1649,10 +1632,6 @@ packages:
 
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
-
-  iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
-    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2135,15 +2114,6 @@ packages:
     resolution: {integrity: sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==}
     engines: {node: '>=16'}
 
-  parse5-htmlparser2-tree-adapter@7.1.0:
-    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
-
-  parse5-parser-stream@7.1.2:
-    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
-
-  parse5@7.3.0:
-    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
-
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2322,9 +2292,6 @@ packages:
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
-
-  safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
@@ -2536,10 +2503,6 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
-    engines: {node: '>=20.18.1'}
-
   unimport@6.3.0:
     resolution: {integrity: sha512-M+Dxk5W9WRd+8j56W9tp8lGW/dmMc7g5zj7BWQnEjKQhryBstqsi1V0izb0zHwSkEN8cSYV7K75/bykairV2tA==}
     engines: {node: '>=18.12.0'}
@@ -2680,15 +2643,6 @@ packages:
 
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
-
-  whatwg-encoding@3.1.1:
-    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
-    engines: {node: '>=18'}
-    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
-
-  whatwg-mimetype@4.0.0:
-    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
-    engines: {node: '>=18'}
 
   when-exit@2.1.5:
     resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
@@ -3631,29 +3585,6 @@ snapshots:
 
   chalk@5.6.2: {}
 
-  cheerio-select@2.1.0:
-    dependencies:
-      boolbase: 1.0.0
-      css-select: 5.2.2
-      css-what: 6.2.2
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      domutils: 3.2.2
-
-  cheerio@1.2.0:
-    dependencies:
-      cheerio-select: 2.1.0
-      dom-serializer: 2.0.0
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      encoding-sniffer: 0.2.1
-      htmlparser2: 10.1.0
-      parse5: 7.3.0
-      parse5-htmlparser2-tree-adapter: 7.1.0
-      parse5-parser-stream: 7.1.2
-      undici: 7.28.0
-      whatwg-mimetype: 4.0.0
-
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
@@ -3818,14 +3749,7 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
-  encoding-sniffer@0.2.1:
-    dependencies:
-      iconv-lite: 0.6.3
-      whatwg-encoding: 3.1.1
-
   entities@4.5.0: {}
-
-  entities@6.0.1: {}
 
   entities@7.0.1: {}
 
@@ -4116,10 +4040,6 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       entities: 7.0.1
-
-  iconv-lite@0.6.3:
-    dependencies:
-      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -4556,19 +4476,6 @@ snapshots:
       lines-and-columns: 2.0.4
       type-fest: 3.13.1
 
-  parse5-htmlparser2-tree-adapter@7.1.0:
-    dependencies:
-      domhandler: 5.0.3
-      parse5: 7.3.0
-
-  parse5-parser-stream@7.1.2:
-    dependencies:
-      parse5: 7.3.0
-
-  parse5@7.3.0:
-    dependencies:
-      entities: 6.0.1
-
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -4785,8 +4692,6 @@ snapshots:
 
   safe-stable-stringify@2.5.0: {}
 
-  safer-buffer@2.1.2: {}
-
   sax@1.6.0: {}
 
   scule@1.3.0: {}
@@ -4992,8 +4897,6 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.28.0: {}
-
   unimport@6.3.0(rolldown@1.0.3):
     dependencies:
       acorn: 8.17.0
@@ -5128,12 +5031,6 @@ snapshots:
   webextension-polyfill@0.12.0: {}
 
   webpack-virtual-modules@0.6.2: {}
-
-  whatwg-encoding@3.1.1:
-    dependencies:
-      iconv-lite: 0.6.3
-
-  whatwg-mimetype@4.0.0: {}
 
   when-exit@2.1.5: {}
 

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -27,6 +27,20 @@ export interface RatingResponse {
   votes: number
 }
 
+export interface UntappdHit {
+  beer_name: string
+  beer_slug: string
+  bid: number
+  brewery_beer_name: string
+  brewery_name: null | string
+  rating_count: null | number
+  rating_score: null | number
+}
+
+export interface UntappdSearchJSON {
+  hits?: UntappdHit[]
+}
+
 export interface VivinoMatch {
   vintage: {
     id: number

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -52,26 +52,29 @@ export async function fetchRatingFromUntappd(
 
     type ScoredBeer = BeerResponse & { similarityRate: number }
 
-    const bestMatch = hits.reduce<null | ScoredBeer>((best, hit: UntappdHit) => {
-      const similarityRate = Math.max(
-        stringSimilarity.compareTwoStrings(productName, hit.beer_name),
-        stringSimilarity.compareTwoStrings(productName, hit.brewery_beer_name)
-      )
+    const bestMatch = hits.reduce<null | ScoredBeer>(
+      (best, hit: UntappdHit) => {
+        const similarityRate = Math.max(
+          stringSimilarity.compareTwoStrings(productName, hit.beer_name),
+          stringSimilarity.compareTwoStrings(productName, hit.brewery_beer_name)
+        )
 
-      const current: ScoredBeer = {
-        brewery: hit.brewery_name,
-        link: `https://untappd.com/b/${hit.beer_slug}/${hit.bid.toString()}`,
-        name: hit.beer_name,
-        // Untappd reports no score (null or 0) for beers with too few
-        // check-ins; normalize to 0 so the UI can render it as "N/A".
-        rating: hit.rating_score ?? 0,
-        similarityRate,
-        status: RatingResultStatus.Found,
-        votes: hit.rating_count ?? 0
-      }
+        const current: ScoredBeer = {
+          brewery: hit.brewery_name,
+          link: `https://untappd.com/b/${hit.beer_slug}/${hit.bid.toString()}`,
+          name: hit.beer_name,
+          // Untappd reports no score (null or 0) for beers with too few
+          // check-ins; normalize to 0 so the UI can render it as "N/A".
+          rating: hit.rating_score ?? 0,
+          similarityRate,
+          status: RatingResultStatus.Found,
+          votes: hit.rating_count ?? 0
+        }
 
-      return similarityRate > (best?.similarityRate ?? 0) ? current : best
-    }, null)
+        return similarityRate > (best?.similarityRate ?? 0) ? current : best
+      },
+      null
+    )
 
     if (!bestMatch || bestMatch.similarityRate < 0.2) {
       return {

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -1,76 +1,86 @@
-import * as cheerio from 'cheerio'
 import stringSimilarity from 'string-similarity'
 
 import {
   BeerResponse,
   RatingResponse,
   RatingResultStatus,
+  UntappdHit,
+  UntappdSearchJSON,
   VivinoMatch,
   VivinoResponseJSON
 } from '@/@types/types'
 
+// Untappd's search page renders results client-side via Algolia; these are the
+// public search-only credentials it ships to anonymous visitors.
+const UNTAPPD_ALGOLIA_APP_ID = '9WBO4RQ3HO'
+const UNTAPPD_ALGOLIA_SEARCH_KEY = '1d347324d67ec472bb7132c66aead485'
+
 export async function fetchRatingFromUntappd(
   productName: string
 ): Promise<RatingResponse> {
-  const url = `https://untappd.com/search?q=${encodeURIComponent(
+  const url = `https://${UNTAPPD_ALGOLIA_APP_ID.toLowerCase()}-dsn.algolia.net/1/indexes/beer/query`
+  const searchFallbackUrl = `https://untappd.com/search?q=${encodeURIComponent(
     productName
   )}&type=beer&sort=all`
-  const headers = {
-    'User-Agent':
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3'
-  }
 
   try {
     const response = await fetch(url, {
-      headers
+      body: JSON.stringify({
+        params: new URLSearchParams({
+          hitsPerPage: '5',
+          query: productName
+        }).toString()
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Algolia-API-Key': UNTAPPD_ALGOLIA_SEARCH_KEY,
+        'X-Algolia-Application-Id': UNTAPPD_ALGOLIA_APP_ID
+      },
+      method: 'POST'
     })
 
     if (!response.ok) {
-      throw new Error(`Failed to fetch: ${response.statusText}`)
-    }
-
-    const html = await response.text()
-    if (html.includes("We didn't find any beers matching")) {
       return { status: RatingResultStatus.NotFound } as RatingResponse
     }
 
-    const $ = cheerio.load(html)
-    const beerCard = $('.beer-item').first()
+    const data = (await response.json()) as UntappdSearchJSON
+    const hits = data.hits ?? []
 
-    const name = beerCard.find('.name').first().text().trim()
-    const similarityRate = stringSimilarity.compareTwoStrings(productName, name)
-    if (similarityRate < 0.2) {
+    if (hits.length === 0) {
+      return { status: RatingResultStatus.NotFound } as RatingResponse
+    }
+
+    type ScoredBeer = BeerResponse & { similarityRate: number }
+
+    const bestMatch = hits.reduce<null | ScoredBeer>((best, hit: UntappdHit) => {
+      const similarityRate = Math.max(
+        stringSimilarity.compareTwoStrings(productName, hit.beer_name),
+        stringSimilarity.compareTwoStrings(productName, hit.brewery_beer_name)
+      )
+
+      const current: ScoredBeer = {
+        brewery: hit.brewery_name,
+        link: `https://untappd.com/b/${hit.beer_slug}/${hit.bid.toString()}`,
+        name: hit.beer_name,
+        // Untappd reports no score (null or 0) for beers with too few
+        // check-ins; normalize to 0 so the UI can render it as "N/A".
+        rating: hit.rating_score ?? 0,
+        similarityRate,
+        status: RatingResultStatus.Found,
+        votes: hit.rating_count ?? 0
+      }
+
+      return similarityRate > (best?.similarityRate ?? 0) ? current : best
+    }, null)
+
+    if (!bestMatch || bestMatch.similarityRate < 0.2) {
       return {
-        link: url,
+        link: searchFallbackUrl,
         status: RatingResultStatus.Uncertain
       } as RatingResponse
     }
 
-    const brewery = beerCard.find('.brewery').first().text().trim()
-    const href = beerCard.find('a').first().attr('href') ?? ''
-    const link = new URL(href, 'https://untappd.com').toString()
-
-    const rating = beerCard.find('.num').first().text().trim()
-
-    const ratingNum = parseFloat(rating.replace('(', '').replace(')', ''))
-
-    const responseDetailPage = await fetch(link, {
-      headers
-    })
-
-    const detailHtml = await responseDetailPage.text()
-    const detailCard = cheerio.load(detailHtml)('.details').first()
-    const lastParagraph = detailCard.find('p').last()
-    const votes = parseInt(lastParagraph.text().replace(/[^0-9]/g, ''), 10)
-
-    return {
-      brewery: brewery,
-      link: link,
-      name: name,
-      rating: ratingNum,
-      status: RatingResultStatus.Found,
-      votes: votes
-    } as BeerResponse
+    return bestMatch
   } catch {
     return { status: RatingResultStatus.NotFound } as RatingResponse
   }
@@ -117,8 +127,8 @@ export async function fetchRatingFromVivino(
     const bestMatch = matches.reduce<null | ScoredWine>(
       (best, match: VivinoMatch) => {
         const wineName = match.vintage.name
-        const rating = match.vintage.statistics.ratings_average ?? -1
-        const votes = match.vintage.statistics.ratings_count ?? -1
+        const rating = match.vintage.statistics.ratings_average ?? 0
+        const votes = match.vintage.statistics.ratings_count ?? 0
         const link = `https://www.vivino.com/wines/${match.vintage.wine.id.toString()}`
         const similarityRate = stringSimilarity.compareTwoStrings(
           query,
@@ -139,12 +149,7 @@ export async function fetchRatingFromVivino(
       null
     )
 
-    if (
-      !bestMatch ||
-      bestMatch.similarityRate < 0.5 ||
-      bestMatch.rating < 0 ||
-      bestMatch.votes < 0
-    ) {
+    if (!bestMatch || bestMatch.similarityRate < 0.5) {
       return {
         link: searchFallbackUrl,
         status: RatingResultStatus.Uncertain

--- a/src/components/domUtils.ts
+++ b/src/components/domUtils.ts
@@ -167,12 +167,18 @@ export function setRating(
       ? generateStarsSvg(rating.rating)
       : generateCapSvg(rating.rating)
 
+  // A score of 0 means the source has too few ratings to compute one yet.
+  const scoreHtml =
+    rating.rating > 0
+      ? `<span class="bp-score">${rating.rating.toString()}</span>
+        <span class="bp-scale">/ 5</span>`
+      : `<span class="bp-score" title="${i18n.t('noRatingYet')}">N/A</span>`
+
   const ratingRow = document.createElement('div')
   ratingRow.className = 'bp-rating-row'
   ratingRow.innerHTML = `
         ${svg}
-        <span class="bp-score">${rating.rating.toString()}</span>
-        <span class="bp-scale">/ 5</span>
+        ${scoreHtml}
       `
 
   const meta = document.createElement('div')

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -3,6 +3,7 @@ linkToUntappd: Link to Untappd
 linkToVivino: Link to Vivino
 loading: Loading...
 noMatch: Sorry, we could not find any rating for this product.
+noRatingYet: Not enough ratings yet
 notOnBottle: The Wine isn't bottled.
 of: of
 rating: Rating

--- a/src/locales/sv.yml
+++ b/src/locales/sv.yml
@@ -3,6 +3,7 @@ linkToUntappd: Länk till Untappd
 linkToVivino: Länk till Vivino
 loading: Laddar...
 noMatch: Tyvärr, vi kunde inte hitta något betyg för denna produkt.
+noRatingYet: Inte tillräckligt många betyg än
 notOnBottle: Vinet är inte på flaska
 of: av
 rating: Betyg

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -36,10 +36,12 @@ export default defineConfig({
     host_permissions: [
       'https://www.systembolaget.se/*',
       'https://www.vivino.com/*',
-      'https://untappd.com/*'
+      'https://untappd.com/*',
+      // Untappd's Algolia search index, used for beer lookups
+      'https://9wbo4rq3ho-dsn.algolia.net/*'
     ],
     content_security_policy: {
-      extension_pages: `script-src 'self'; object-src 'self'; connect-src 'self' https://www.vivino.com https://untappd.com${isProduction ? '' : ' ws://localhost:3000/'};`
+      extension_pages: `script-src 'self'; object-src 'self'; connect-src 'self' https://www.vivino.com https://untappd.com https://9wbo4rq3ho-dsn.algolia.net${isProduction ? '' : ' ws://localhost:3000/'};`
     },
     browser_specific_settings: {
       gecko: {


### PR DESCRIPTION
## Summary

- Query Untappd's public Algolia search index (the same one its own search page uses) instead of scraping search + detail HTML with cheerio; rating and vote count come straight from the hit, removing the second request
- Score all 5 hits by name similarity and pick the best instead of blindly taking the first result
- Add the Algolia host to `host_permissions` and the extension CSP `connect-src` — the fetch runs in the background service worker, and without these the request is silently CSP-blocked and every beer shows "no rating found"
- Treat a missing/zero score as "not enough ratings yet": keep the matched product's card and direct link but render N/A instead of a misleading 0 / 5 (applies to both Untappd and Vivino)
- Drop the now-unused cheerio dependency

## Test plan

- [x] `pnpm compile`, `pnpm lint` clean
- [x] Full Playwright suite 6/6 (live API integration + browser e2e)
- [x] Manually verified 16 live product pages (beers, wines, box/can wines, spirits) plus SPA navigation between products
- [x] Verified N/A rendering on a low-check-in beer (Oppigårds Cherry Sour Ale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)