### PR TITLE
fix: return Uncertain with a search link on Vivino lookup misses

### DIFF
--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -15,11 +15,47 @@ test.describe('API Integration Tests', () => {
 
   test('fetchRatingFromUntappd returns data for valid query', async () => {
     const result = await fetchRatingFromUntappd('Pabst Blue Ribbon');
-    
+
     expect(result).not.toBeNull();
     expect(result?.status).toBe(RatingResultStatus.Found);
     expect(result?.rating).toBeGreaterThan(0);
     expect(result?.votes).toBeGreaterThan(0);
     expect(result?.link).toContain('untappd.com');
+  });
+});
+
+// Offline tests: the Vivino explore API only indexes marketplace wines, so a
+// miss must surface an Uncertain result with a working search link — never a
+// dead-end NotFound.
+test.describe('Vivino lookup misses (mocked fetch)', () => {
+  const realFetch = globalThis.fetch;
+
+  test.afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  test('returns Uncertain with a search link when the explore API has no matches', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ explore_vintage: { matches: [] } })
+      } as Response)) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Torre do Olivar');
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.link).toBe(
+      'https://www.vivino.com/search/wines?q=Torre%20do%20Olivar'
+    );
+  });
+
+  test('returns Uncertain with a search link when the request fails', async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(new Error('network down'))) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Some Obscure Wine');
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.link).toContain('vivino.com/search/wines');
   });
 });

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -102,7 +102,13 @@ export async function fetchRatingFromVivino(
     search_term: query
   })
   const url = `https://www.vivino.com/api/explore/explore?${params.toString()}`
-  const searchFallbackUrl = `https://www.vivino.com/search/wines?q=${encodeURIComponent(query)}`
+  // Vivino's explore API only indexes marketplace wines, so misses are common
+  // (catalogue-only wines, regional gaps). Instead of a dead-end "no rating"
+  // message, always hand the user a working Vivino search link.
+  const uncertainFallback = {
+    link: `https://www.vivino.com/search/wines?q=${encodeURIComponent(query)}`,
+    status: RatingResultStatus.Uncertain
+  } as RatingResponse
 
   try {
     const response = await fetch(url, {
@@ -115,14 +121,14 @@ export async function fetchRatingFromVivino(
     })
 
     if (!response.ok) {
-      return { status: RatingResultStatus.NotFound } as RatingResponse
+      return uncertainFallback
     }
 
     const data = (await response.json()) as VivinoResponseJSON
     const matches = data.explore_vintage?.matches ?? []
 
     if (matches.length === 0) {
-      return { status: RatingResultStatus.NotFound } as RatingResponse
+      return uncertainFallback
     }
 
     type ScoredWine = RatingResponse & { similarityRate: number }
@@ -153,14 +159,11 @@ export async function fetchRatingFromVivino(
     )
 
     if (!bestMatch || bestMatch.similarityRate < 0.5) {
-      return {
-        link: searchFallbackUrl,
-        status: RatingResultStatus.Uncertain
-      } as RatingResponse
+      return uncertainFallback
     }
 
     return bestMatch
   } catch {
-    return { status: RatingResultStatus.NotFound } as RatingResponse
+    return uncertainFallback
   }
 }


### PR DESCRIPTION
Replaces #102 (adapted to the current codebase — see below).

## Summary

- A Vivino lookup miss (no matches, low-confidence match, non-OK response, or network failure) now always surfaces an **Uncertain result with a working Vivino search link** instead of the dead-end "no rating found" message.
- Adds offline mocked-fetch tests for the no-match and network-failure paths.

## Why the scrape fallback from #102 was dropped

#102 proposed recovering catalogue-only wines by scraping `vivino.com/search/wines`. Verified live today:

- `/search/wines` now just **302-redirects to the explore page**, which is client-rendered from the same marketplace-only explore API — the wine cards and selectors #102 parses (`.default-wine-card`, `.average__number`) no longer exist in the HTML, and no richer search endpoint is called by the page at all.
- The motivating example wine (Torre do Olivar, `/w/172616684`) returns 404 — it no longer exists on Vivino.
- The scrape also depended on cheerio, which was removed in #103.

So there is no data source left for a fallback; what remains valuable from #102 is the no-dead-ends UX, which this PR keeps.

Stacked on #103 — merge that first and this diff collapses to the two files above.

## Test plan

- [x] `pnpm compile`, `pnpm lint` clean
- [x] Full Playwright suite 8/8 (live API + browser e2e + new mocked tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)