### PR TITLE
feat: add ratings support for cider & mixed drinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A browser plugin for Systembolaget.se that shows ratings directly at systembolag
 - Seamless integration with Systembolaget's website
 - Wine ratings from [Vivino](https://www.vivino.com/) with direct links to product pages
 - Beer ratings from [Untappd](https://untappd.com/) with direct links to product pages
+- Cider & mixed drink ratings from [Untappd](https://untappd.com/) with direct links to product pages
 - Easy toggling of features through a simple popup interface
 - Works with both Firefox and Chrome browsers
 
@@ -28,6 +29,7 @@ Or download the latest zip from the [Github Releases](https://github.com/Broadca
 4. Use the extension popup to:
    - Disable wine ratings.
    - Disable beer ratings.
+   - Disable cider & mixed drink ratings.
    - Disable the extension entirely.
 
 ## Development

--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -22,6 +22,16 @@ test.describe('API Integration Tests', () => {
     expect(result?.votes).toBeGreaterThan(0);
     expect(result?.link).toContain('untappd.com');
   });
+
+  test('fetchRatingFromUntappd returns data for a cider query', async () => {
+    const result = await fetchRatingFromUntappd('Rekorderlig Päron');
+
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe(RatingResultStatus.Found);
+    expect(result?.rating).toBeGreaterThan(0);
+    expect(result?.votes).toBeGreaterThan(0);
+    expect(result?.link).toContain('untappd.com');
+  });
 });
 
 // Offline tests: the Vivino explore API only indexes marketplace wines, so a

--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -15,11 +15,47 @@ test.describe('API Integration Tests', () => {
 
   test('fetchRatingFromUntappd returns data for valid query', async () => {
     const result = await fetchRatingFromUntappd('Pabst Blue Ribbon');
-    
+
     expect(result).not.toBeNull();
     expect(result?.status).toBe(RatingResultStatus.Found);
     expect(result?.rating).toBeGreaterThan(0);
     expect(result?.votes).toBeGreaterThan(0);
     expect(result?.link).toContain('untappd.com');
+  });
+});
+
+// Offline tests: the Vivino explore API only indexes marketplace wines, so a
+// miss must surface an Uncertain result with a working search link — never a
+// dead-end NotFound.
+test.describe('Vivino lookup misses (mocked fetch)', () => {
+  const realFetch = globalThis.fetch;
+
+  test.afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  test('returns Uncertain with a search link when the explore API has no matches', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ explore_vintage: { matches: [] } })
+      } as Response)) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Torre do Olivar');
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.link).toBe(
+      'https://www.vivino.com/search/wines?q=Torre%20do%20Olivar'
+    );
+  });
+
+  test('returns Uncertain with a search link when the request fails', async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(new Error('network down'))) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Some Obscure Wine');
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.link).toContain('vivino.com/search/wines');
   });
 });

--- a/e2e/end-to-end.spec.ts
+++ b/e2e/end-to-end.spec.ts
@@ -47,6 +47,33 @@ test('visiting beer page shows rating-container with votes', async ({
   expect(res).toMatch(/(votes|röster)/i)
 })
 
+test('visiting cider page shows rating-container with votes', async ({
+  page,
+  extensionId
+}) => {
+  // arrange
+  await page.goto(`chrome-extension://${extensionId}/popup.html`)
+  await page.waitForSelector('.settings')
+  await expect(page.locator('#enabled')).toBeChecked()
+  await expect(page.locator('#cider')).toBeChecked()
+
+  // act
+  await page.goto(
+    'https://www.systembolaget.se/produkt/cider-blanddrycker/somersby-182435/'
+  )
+  await page.getByRole('link', { name: 'Jag har fyllt 20 år' }).click()
+  await page.getByRole('button', { name: 'Acceptera alla kakor' }).click()
+  await page.reload()
+  await page.locator('#rating-container').waitFor()
+
+  // Wait for the spinner to be removed
+  await page.waitForSelector('.bp-spinner', { state: 'detached' });
+  await page.waitForSelector('#rating-container-body');
+  // assert
+  const res = await page.locator('#rating-container').textContent()
+  expect(res).toMatch(/(votes|röster)/i)
+})
+
 test('visiting a wine page with wine toggle disabled should not show wine', async ({
   page,
   extensionId

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -1,5 +1,6 @@
 export enum ProductType {
   Beer = 'beer',
+  Cider = 'cider',
   Uncertain = 'uncertain',
   Wine = 'wine'
 }

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -102,7 +102,13 @@ export async function fetchRatingFromVivino(
     search_term: query
   })
   const url = `https://www.vivino.com/api/explore/explore?${params.toString()}`
-  const searchFallbackUrl = `https://www.vivino.com/search/wines?q=${encodeURIComponent(query)}`
+  // Vivino's explore API only indexes marketplace wines, so misses are common
+  // (catalogue-only wines, regional gaps). Instead of a dead-end "no rating"
+  // message, always hand the user a working Vivino search link.
+  const uncertainFallback = {
+    link: `https://www.vivino.com/search/wines?q=${encodeURIComponent(query)}`,
+    status: RatingResultStatus.Uncertain
+  } as RatingResponse
 
   try {
     const response = await fetch(url, {
@@ -115,14 +121,14 @@ export async function fetchRatingFromVivino(
     })
 
     if (!response.ok) {
-      return { status: RatingResultStatus.NotFound } as RatingResponse
+      return uncertainFallback
     }
 
     const data = (await response.json()) as VivinoResponseJSON
     const matches = data.explore_vintage?.matches ?? []
 
     if (matches.length === 0) {
-      return { status: RatingResultStatus.NotFound } as RatingResponse
+      return uncertainFallback
     }
 
     type ScoredWine = RatingResponse & { similarityRate: number }
@@ -153,14 +159,11 @@ export async function fetchRatingFromVivino(
     )
 
     if (!bestMatch || bestMatch.similarityRate < 0.5) {
-      return {
-        link: searchFallbackUrl,
-        status: RatingResultStatus.Uncertain
-      } as RatingResponse
+      return uncertainFallback
     }
 
     return bestMatch
   } catch {
-    return { status: RatingResultStatus.NotFound } as RatingResponse
+    return uncertainFallback
   }
 }

--- a/src/components/domUtils.ts
+++ b/src/components/domUtils.ts
@@ -184,7 +184,7 @@ export function setRating(
   const meta = document.createElement('div')
   meta.className = 'bp-meta'
   meta.innerText = `${rating.votes.toString()} ${i18n.t('votes')}`
-  if (productType === ProductType.Beer) {
+  if (productType !== ProductType.Wine) {
     const beerRating = rating as BeerResponse
     if (beerRating.brewery) {
       meta.innerText += ` · ${beerRating.brewery}`
@@ -192,9 +192,9 @@ export function setRating(
   }
 
   const linkLabel =
-    productType === ProductType.Beer
-      ? i18n.t('linkToUntappd')
-      : i18n.t('linkToVivino')
+    productType === ProductType.Wine
+      ? i18n.t('linkToVivino')
+      : i18n.t('linkToUntappd')
 
   const footer = document.createElement('div')
   footer.className = 'bp-footer'
@@ -213,9 +213,9 @@ export function setUncertain(productType: ProductType, link: null | string) {
   message.innerText = i18n.t('uncertainMatch')
 
   const linkLabel =
-    productType === ProductType.Beer
-      ? i18n.t('searchAtUntappd')
-      : i18n.t('searchAtVivino')
+    productType === ProductType.Wine
+      ? i18n.t('searchAtVivino')
+      : i18n.t('searchAtUntappd')
 
   const footer = document.createElement('div')
   footer.className = 'bp-footer'

--- a/src/components/productUtils.ts
+++ b/src/components/productUtils.ts
@@ -32,6 +32,10 @@ export function getProductType(): ProductType {
     return ProductType.Beer
   }
 
+  if (url.includes('/produkt/cider-blanddrycker/')) {
+    return ProductType.Cider
+  }
+
   return ProductType.Uncertain
 }
 

--- a/src/components/settings.ts
+++ b/src/components/settings.ts
@@ -20,3 +20,10 @@ export const beerFeatureEnabled = storage.defineItem<boolean>(
     fallback: true
   }
 )
+
+export const ciderFeatureEnabled = storage.defineItem<boolean>(
+  'sync:ciderFeatureEnabled',
+  {
+    fallback: true
+  }
+)

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -23,6 +23,7 @@ browser.runtime.onMessage.addListener(async (message: unknown) => {
   const { productName, query } = message
   switch (query) {
     case ProductType.Beer:
+    case ProductType.Cider:
       return await fetchRatingFromUntappd(productName)
     case ProductType.Wine:
       return await fetchRatingFromVivino(productName)

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -8,7 +8,11 @@ import {
 import * as domUtils from '@/components/domUtils'
 import * as productUtils from '@/components/productUtils'
 import { fetchRating } from '@/components/ratingService'
-import { wineFeatureEnabled } from '@/components/settings'
+import {
+  beerFeatureEnabled,
+  ciderFeatureEnabled,
+  wineFeatureEnabled
+} from '@/components/settings'
 
 export default defineContentScript({
   main() {
@@ -28,7 +32,10 @@ async function featureEnabled(productType: ProductType): Promise<boolean> {
   if (
     (productType === ProductType.Wine &&
       !(await wineFeatureEnabled.getValue())) ||
-    (productType === ProductType.Beer && !(await beerFeatureEnabled.getValue()))
+    (productType === ProductType.Beer &&
+      !(await beerFeatureEnabled.getValue())) ||
+    (productType === ProductType.Cider &&
+      !(await ciderFeatureEnabled.getValue()))
   ) {
     return false
   }

--- a/src/entrypoints/popup/index.html
+++ b/src/entrypoints/popup/index.html
@@ -51,6 +51,13 @@
                         <span class="slider"></span>
                     </label>
                 </div>
+                <div class="toggle-container">
+                    <span class="toggle-label">Cider &amp; blanddryck</span>
+                    <label class="switch">
+                        <input type="checkbox" id="cider" name="cider">
+                        <span class="slider"></span>
+                    </label>
+                </div>
                 <!-- <div class="toggle-container">
                     <span class="toggle-label">Sprit</span>
                     <label class="switch">

--- a/src/entrypoints/popup/main.ts
+++ b/src/entrypoints/popup/main.ts
@@ -1,6 +1,7 @@
 import { getLatestRelease, version } from '@/components/github'
 import {
   beerFeatureEnabled,
+  ciderFeatureEnabled,
   featuresEnabled,
   wineFeatureEnabled
 } from '@/components/settings'
@@ -54,6 +55,12 @@ async function setupToggles(): Promise<void> {
   beerToggle.checked = await beerFeatureEnabled.getValue()
   beerToggle.addEventListener('change', () => {
     void beerFeatureEnabled.setValue(beerToggle.checked)
+  })
+
+  const ciderToggle = document.getElementById('cider') as HTMLInputElement
+  ciderToggle.checked = await ciderFeatureEnabled.getValue()
+  ciderToggle.addEventListener('change', () => {
+    void ciderFeatureEnabled.setValue(ciderToggle.checked)
   })
 }
 


### PR DESCRIPTION
Replaces #101, rebased onto the current codebase (post-#103/#104: Untappd on Algolia, renamed i18n keys, per-product SPA request tracking).

## Summary

- Add `ProductType.Cider` and detect `/produkt/cider-blanddrycker/` URLs
- Route cider lookups through the existing Untappd fetcher (Untappd indexes ciders, seltzers and mixed drinks)
- Add a `ciderFeatureEnabled` setting and popup toggle
- Render cider with the Untappd source (caps, producer, Untappd link) by keying source-specific rendering on wine-vs-Untappd
- README note + API integration test + browser e2e test against a live cider product

Stacked on #104 — merge order: #103 → #104 → this.

## Test plan

- [x] `pnpm compile`, `pnpm lint` clean
- [x] Full Playwright suite 10/10, including the new live cider API test and cider page e2e (Somersby renders a rating card with votes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)