### PR TITLE
feat: show ratings on product list pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A browser plugin for Systembolaget.se that shows ratings directly at systembolag
 - Seamless integration with Systembolaget's website
 - Wine ratings from [Vivino](https://www.vivino.com/) with direct links to product pages
 - Beer ratings from [Untappd](https://untappd.com/) with direct links to product pages
+- Cider & mixed drink ratings from [Untappd](https://untappd.com/) with direct links to product pages
 - Easy toggling of features through a simple popup interface
 - Works with both Firefox and Chrome browsers
 
@@ -28,6 +29,7 @@ Or download the latest zip from the [Github Releases](https://github.com/Broadca
 4. Use the extension popup to:
    - Disable wine ratings.
    - Disable beer ratings.
+   - Disable cider & mixed drink ratings.
    - Disable the extension entirely.
 
 ## Development

--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -22,6 +22,16 @@ test.describe('API Integration Tests', () => {
     expect(result?.votes).toBeGreaterThan(0);
     expect(result?.link).toContain('untappd.com');
   });
+
+  test('fetchRatingFromUntappd returns data for a cider query', async () => {
+    const result = await fetchRatingFromUntappd('Rekorderlig Päron');
+
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe(RatingResultStatus.Found);
+    expect(result?.rating).toBeGreaterThan(0);
+    expect(result?.votes).toBeGreaterThan(0);
+    expect(result?.link).toContain('untappd.com');
+  });
 });
 
 // Offline tests: the Vivino explore API only indexes marketplace wines, so a

--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -15,11 +15,47 @@ test.describe('API Integration Tests', () => {
 
   test('fetchRatingFromUntappd returns data for valid query', async () => {
     const result = await fetchRatingFromUntappd('Pabst Blue Ribbon');
-    
+
     expect(result).not.toBeNull();
     expect(result?.status).toBe(RatingResultStatus.Found);
     expect(result?.rating).toBeGreaterThan(0);
     expect(result?.votes).toBeGreaterThan(0);
     expect(result?.link).toContain('untappd.com');
+  });
+});
+
+// Offline tests: the Vivino explore API only indexes marketplace wines, so a
+// miss must surface an Uncertain result with a working search link — never a
+// dead-end NotFound.
+test.describe('Vivino lookup misses (mocked fetch)', () => {
+  const realFetch = globalThis.fetch;
+
+  test.afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  test('returns Uncertain with a search link when the explore API has no matches', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ explore_vintage: { matches: [] } })
+      } as Response)) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Torre do Olivar');
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.link).toBe(
+      'https://www.vivino.com/search/wines?q=Torre%20do%20Olivar'
+    );
+  });
+
+  test('returns Uncertain with a search link when the request fails', async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(new Error('network down'))) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Some Obscure Wine');
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.link).toContain('vivino.com/search/wines');
   });
 });

--- a/e2e/end-to-end.spec.ts
+++ b/e2e/end-to-end.spec.ts
@@ -133,3 +133,21 @@ test('visiting a wine page shows rating-container with ratings and stars', async
   const vivinoLink = ratingContainer.locator('a[href*="vivino.com"]');
   await expect(vivinoLink).toBeVisible();
 });
+
+test('visiting wine list page shows rating badges on product cards', async ({
+  page,
+  extensionId
+}) => {
+  await page.goto(`chrome-extension://${extensionId}/popup.html`)
+  await page.waitForSelector('.settings')
+  await expect(page.locator('#enabled')).toBeChecked()
+  await expect(page.locator('#wine')).toBeChecked()
+
+  await page.goto('https://www.systembolaget.se/sortiment/vin/')
+  await page.getByRole('link', { name: 'Jag har fyllt 20 år' }).click()
+  await page.getByRole('button', { name: 'Acceptera alla kakor' }).click()
+  await page.reload()
+
+  await page.waitForSelector('.bp-card-rating', { timeout: 20000 })
+  await expect(page.locator('.bp-card-rating').first()).toBeVisible()
+})

--- a/e2e/end-to-end.spec.ts
+++ b/e2e/end-to-end.spec.ts
@@ -47,6 +47,33 @@ test('visiting beer page shows rating-container with votes', async ({
   expect(res).toMatch(/(votes|röster)/i)
 })
 
+test('visiting cider page shows rating-container with votes', async ({
+  page,
+  extensionId
+}) => {
+  // arrange
+  await page.goto(`chrome-extension://${extensionId}/popup.html`)
+  await page.waitForSelector('.settings')
+  await expect(page.locator('#enabled')).toBeChecked()
+  await expect(page.locator('#cider')).toBeChecked()
+
+  // act
+  await page.goto(
+    'https://www.systembolaget.se/produkt/cider-blanddrycker/somersby-182435/'
+  )
+  await page.getByRole('link', { name: 'Jag har fyllt 20 år' }).click()
+  await page.getByRole('button', { name: 'Acceptera alla kakor' }).click()
+  await page.reload()
+  await page.locator('#rating-container').waitFor()
+
+  // Wait for the spinner to be removed
+  await page.waitForSelector('.bp-spinner', { state: 'detached' });
+  await page.waitForSelector('#rating-container-body');
+  // assert
+  const res = await page.locator('#rating-container').textContent()
+  expect(res).toMatch(/(votes|röster)/i)
+})
+
 test('visiting a wine page with wine toggle disabled should not show wine', async ({
   page,
   extensionId

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -1,5 +1,6 @@
 export enum ProductType {
   Beer = 'beer',
+  Cider = 'cider',
   Uncertain = 'uncertain',
   Wine = 'wine'
 }

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -16,6 +16,7 @@ export type BeerResponse = RatingResponse & {
 }
 
 export interface RatingRequest {
+  productId: string
   productName: string
   query: ProductType
 }

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -102,7 +102,13 @@ export async function fetchRatingFromVivino(
     search_term: query
   })
   const url = `https://www.vivino.com/api/explore/explore?${params.toString()}`
-  const searchFallbackUrl = `https://www.vivino.com/search/wines?q=${encodeURIComponent(query)}`
+  // Vivino's explore API only indexes marketplace wines, so misses are common
+  // (catalogue-only wines, regional gaps). Instead of a dead-end "no rating"
+  // message, always hand the user a working Vivino search link.
+  const uncertainFallback = {
+    link: `https://www.vivino.com/search/wines?q=${encodeURIComponent(query)}`,
+    status: RatingResultStatus.Uncertain
+  } as RatingResponse
 
   try {
     const response = await fetch(url, {
@@ -115,14 +121,14 @@ export async function fetchRatingFromVivino(
     })
 
     if (!response.ok) {
-      return { status: RatingResultStatus.NotFound } as RatingResponse
+      return uncertainFallback
     }
 
     const data = (await response.json()) as VivinoResponseJSON
     const matches = data.explore_vintage?.matches ?? []
 
     if (matches.length === 0) {
-      return { status: RatingResultStatus.NotFound } as RatingResponse
+      return uncertainFallback
     }
 
     type ScoredWine = RatingResponse & { similarityRate: number }
@@ -153,14 +159,11 @@ export async function fetchRatingFromVivino(
     )
 
     if (!bestMatch || bestMatch.similarityRate < 0.5) {
-      return {
-        link: searchFallbackUrl,
-        status: RatingResultStatus.Uncertain
-      } as RatingResponse
+      return uncertainFallback
     }
 
     return bestMatch
   } catch {
-    return { status: RatingResultStatus.NotFound } as RatingResponse
+    return uncertainFallback
   }
 }

--- a/src/components/domUtils.ts
+++ b/src/components/domUtils.ts
@@ -184,7 +184,7 @@ export function setRating(
   const meta = document.createElement('div')
   meta.className = 'bp-meta'
   meta.innerText = `${rating.votes.toString()} ${i18n.t('votes')}`
-  if (productType === ProductType.Beer) {
+  if (productType !== ProductType.Wine) {
     const beerRating = rating as BeerResponse
     if (beerRating.brewery) {
       meta.innerText += ` · ${beerRating.brewery}`
@@ -192,9 +192,9 @@ export function setRating(
   }
 
   const linkLabel =
-    productType === ProductType.Beer
-      ? i18n.t('linkToUntappd')
-      : i18n.t('linkToVivino')
+    productType === ProductType.Wine
+      ? i18n.t('linkToVivino')
+      : i18n.t('linkToUntappd')
 
   const footer = document.createElement('div')
   footer.className = 'bp-footer'
@@ -213,9 +213,9 @@ export function setUncertain(productType: ProductType, link: null | string) {
   message.innerText = i18n.t('uncertainMatch')
 
   const linkLabel =
-    productType === ProductType.Beer
-      ? i18n.t('searchAtUntappd')
-      : i18n.t('searchAtVivino')
+    productType === ProductType.Wine
+      ? i18n.t('searchAtVivino')
+      : i18n.t('searchAtUntappd')
 
   const footer = document.createElement('div')
   footer.className = 'bp-footer'

--- a/src/components/domUtils.ts
+++ b/src/components/domUtils.ts
@@ -1,6 +1,11 @@
 import { i18n } from '#i18n'
 
-import { BeerResponse, ProductType, RatingResponse } from '@/@types/types'
+import {
+  BeerResponse,
+  ProductType,
+  RatingResponse,
+  RatingResultStatus
+} from '@/@types/types'
 
 const RATING_CONTAINER_ID = 'rating-container'
 const RATING_CONTAINER_BODY_ID = 'rating-container-body'
@@ -102,6 +107,32 @@ const STYLES = `
   @keyframes bp-spin {
     to { transform: rotate(360deg); }
   }
+  .bp-card-rating {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 4px;
+  }
+  .bp-card-rating svg { width: 14px; height: 14px; }
+  .bp-card-rating .bp-card-score {
+    font-weight: 700;
+    font-size: 12px;
+    color: #1a1a1a;
+  }
+  .bp-card-rating .bp-card-votes {
+    color: #888;
+    font-size: 11px;
+  }
+  .bp-card-spinner-inline {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    margin-top: 6px;
+    border: 2px solid #e8e8e8;
+    border-top-color: #095741;
+    border-radius: 50%;
+    animation: bp-spin 0.8s linear infinite;
+  }
 `
 
 export function getAndClearContainer(): HTMLElement {
@@ -139,12 +170,7 @@ export function injectRatingContainer() {
     )
   }
 
-  if (!document.getElementById(STYLE_ID)) {
-    const style = document.createElement('style')
-    style.id = STYLE_ID
-    style.textContent = STYLES
-    document.head.appendChild(style)
-  }
+  ensureStyles()
 }
 
 export function setMessage(message: string) {
@@ -258,6 +284,14 @@ function createSourceLink(
   return linkElement
 }
 
+function ensureStyles(): void {
+  if (document.getElementById(STYLE_ID)) return
+  const style = document.createElement('style')
+  style.id = STYLE_ID
+  style.textContent = STYLES
+  document.head.appendChild(style)
+}
+
 function generateCapSvg(rating: number): string {
   const maxCaps = 5
   const yellowColor = '#ffc000'
@@ -291,6 +325,45 @@ function generateCapSvg(rating: number): string {
   }
 
   return `<div style="display: flex">${capsHtml}</div>`
+}
+
+const CARD_RATING_CLASS = 'bp-card-rating'
+
+export function injectCardSpinner(card: Element): HTMLElement | null {
+  if (card.querySelector(`.${CARD_RATING_CLASS}, .bp-card-spinner-inline`)) {
+    return null
+  }
+  ensureStyles()
+  const lastNameSpan = [...card.querySelectorAll('.monopol-250')].at(-1)
+  if (!lastNameSpan) return null
+
+  const spinner = document.createElement('div')
+  spinner.className = 'bp-card-spinner-inline'
+  lastNameSpan.insertAdjacentElement('afterend', spinner)
+  return spinner
+}
+
+export function replaceCardSpinner(
+  spinner: HTMLElement,
+  productType: ProductType,
+  rating: RatingResponse
+): void {
+  if (rating.status !== RatingResultStatus.Found) {
+    spinner.remove()
+    return
+  }
+  const svg =
+    productType === ProductType.Wine
+      ? generateStarsSvg(rating.rating)
+      : generateCapSvg(rating.rating)
+  const badge = document.createElement('div')
+  badge.className = CARD_RATING_CLASS
+  badge.innerHTML = `
+    ${svg}
+    <span class="bp-card-score">${rating.rating.toString()}</span>
+    <span class="bp-card-votes">(${rating.votes.toString()})</span>
+  `
+  spinner.replaceWith(badge)
 }
 
 function generateStarsSvg(rating: number): string {

--- a/src/components/productUtils.ts
+++ b/src/components/productUtils.ts
@@ -32,6 +32,10 @@ export function getProductType(): ProductType {
     return ProductType.Beer
   }
 
+  if (url.includes('/produkt/cider-blanddrycker/')) {
+    return ProductType.Cider
+  }
+
   return ProductType.Uncertain
 }
 

--- a/src/components/productUtils.ts
+++ b/src/components/productUtils.ts
@@ -1,5 +1,34 @@
 import { ProductType } from '@/@types/types'
 
+export function getCardName(card: Element): null | string {
+  const spans = [...card.querySelectorAll('.monopol-250')] as HTMLElement[]
+  if (spans.length === 0) return null
+  const parts = spans.map((s) => s.innerText.trim()).filter(Boolean)
+  // Normalize ", 2025" → " 2025" so vintage year is included without comma
+  return (
+    parts
+      .join(' ')
+      .replace(/,\s*(\d{4})/, ' $1')
+      .trim() || null
+  )
+}
+
+export function getCardProductId(card: Element): null | string {
+  return extractProductId(card.getAttribute('href') ?? '')
+}
+
+export function getCardProductType(card: Element): ProductType {
+  const href = card.getAttribute('href') ?? ''
+  if (href.includes('/produkt/vin/')) return ProductType.Wine
+  if (href.includes('/produkt/ol/')) return ProductType.Beer
+  if (href.includes('/produkt/cider-blanddrycker/')) return ProductType.Cider
+  return ProductType.Uncertain
+}
+
+export function getProductId(): null | string {
+  return extractProductId(window.location.href)
+}
+
 export function getProductName(): null | string {
   const headerChildren = document.querySelector('main h1')?.children
 
@@ -67,6 +96,14 @@ export function isBottle(): boolean {
   }
 
   return !NON_BOTTLE_FORMATS.some((format) => descriptor.includes(format))
+}
+
+export function isListPage(): boolean {
+  return window.location.pathname.includes('/sortiment/')
+}
+
+function extractProductId(url: string): null | string {
+  return /-(\d+)\/?$/.exec(url)?.[1] ?? null
 }
 
 // Reads the packaging type from the format line under the product title, which

--- a/src/components/ratingService.ts
+++ b/src/components/ratingService.ts
@@ -10,11 +10,12 @@ import {
 import { saveRating as cacheRating, tryGetRating } from './ratingsCache'
 
 export async function fetchRating(
+  productId: string,
   productName: string,
   type: ProductType
 ): Promise<RatingResponse> {
   try {
-    const ratingRequest = { productName, query: type }
+    const ratingRequest = { productId, productName, query: type }
     const cachedRating = await tryGetRating(ratingRequest)
     if (cachedRating) {
       return cachedRating
@@ -31,4 +32,25 @@ export async function fetchRating(
   } catch {
     return { status: RatingResultStatus.NotFound } as RatingResponse
   }
+}
+
+const LIST_FETCH_DELAY_MS = 300
+
+let listFetchQueue: Promise<undefined> = Promise.resolve(undefined)
+
+export function enqueueListFetch(
+  productId: string,
+  productName: string,
+  type: ProductType
+): Promise<RatingResponse> {
+  const task = listFetchQueue.then(
+    () =>
+      new Promise<RatingResponse>((resolve) => {
+        setTimeout(() => {
+          void fetchRating(productId, productName, type).then(resolve)
+        }, LIST_FETCH_DELAY_MS)
+      })
+  )
+  listFetchQueue = task.then(() => undefined)
+  return task
 }

--- a/src/components/ratingsCache.ts
+++ b/src/components/ratingsCache.ts
@@ -51,5 +51,5 @@ function calculateDaysDifference(date1: Date, date2: Date): number {
 }
 
 function generateCacheKey(ratingRequest: RatingRequest): `local:${string}` {
-  return `local:ratings:${ratingRequest.productName}-${ratingRequest.query}`
+  return `local:ratings:${ratingRequest.productId}-${ratingRequest.query}`
 }

--- a/src/components/settings.ts
+++ b/src/components/settings.ts
@@ -20,3 +20,10 @@ export const beerFeatureEnabled = storage.defineItem<boolean>(
     fallback: true
   }
 )
+
+export const ciderFeatureEnabled = storage.defineItem<boolean>(
+  'sync:ciderFeatureEnabled',
+  {
+    fallback: true
+  }
+)

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -23,6 +23,7 @@ browser.runtime.onMessage.addListener(async (message: unknown) => {
   const { productName, query } = message
   switch (query) {
     case ProductType.Beer:
+    case ProductType.Cider:
       return await fetchRatingFromUntappd(productName)
     case ProductType.Wine:
       return await fetchRatingFromVivino(productName)

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -7,7 +7,7 @@ import {
 } from '@/@types/types'
 import * as domUtils from '@/components/domUtils'
 import * as productUtils from '@/components/productUtils'
-import { fetchRating } from '@/components/ratingService'
+import { enqueueListFetch, fetchRating } from '@/components/ratingService'
 import {
   beerFeatureEnabled,
   ciderFeatureEnabled,
@@ -16,9 +16,23 @@ import {
 
 export default defineContentScript({
   main() {
+    const listCardObserver = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue
+          listCardObserver.unobserve(entry.target)
+          void handleListCard(entry.target)
+        }
+      },
+      { rootMargin: '200px' }
+    )
+
     //eslint-disable-next-line @typescript-eslint/no-misused-promises
     sentinel.on('h1', tryInsertOnProductPage)
     void tryInsertOnProductPage()
+    sentinel.on('a[id^="tile:"]', (card) => {
+      listCardObserver.observe(card)
+    })
   },
   matches: ['*://*.systembolaget.se/*']
 })
@@ -40,6 +54,27 @@ async function featureEnabled(productType: ProductType): Promise<boolean> {
     return false
   }
   return true
+}
+
+async function handleListCard(card: Element) {
+  if (!(await featuresEnabled.getValue())) return
+  const productType = productUtils.getCardProductType(card)
+  if (
+    productType === ProductType.Uncertain ||
+    !(await featureEnabled(productType))
+  ) {
+    return
+  }
+
+  const productId = productUtils.getCardProductId(card)
+  const name = productUtils.getCardName(card)
+  if (!productId || !name) return
+
+  const spinner = domUtils.injectCardSpinner(card)
+  if (!spinner) return
+
+  const rating = await enqueueListFetch(productId, name, productType)
+  domUtils.replaceCardSpinner(spinner, productType, rating)
 }
 
 function handleRating(productType: ProductType, rating: RatingResponse) {
@@ -73,8 +108,13 @@ async function tryInsertOnProductPage() {
     return
   }
 
+  const productId = productUtils.getProductId()
   const productName = productUtils.getProductName()
-  if (!productName || activeRequest?.productName === productName) {
+  if (
+    !productId ||
+    !productName ||
+    activeRequest?.productName === productName
+  ) {
     return
   }
 
@@ -83,7 +123,7 @@ async function tryInsertOnProductPage() {
   try {
     domUtils.showLoadingSpinner()
 
-    const rating = await fetchRating(productName, productType)
+    const rating = await fetchRating(productId, productName, productType)
     if (activeRequest !== request) return
     handleRating(productType, rating)
   } catch {

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -8,7 +8,11 @@ import {
 import * as domUtils from '@/components/domUtils'
 import * as productUtils from '@/components/productUtils'
 import { fetchRating } from '@/components/ratingService'
-import { wineFeatureEnabled } from '@/components/settings'
+import {
+  beerFeatureEnabled,
+  ciderFeatureEnabled,
+  wineFeatureEnabled
+} from '@/components/settings'
 
 export default defineContentScript({
   main() {
@@ -28,7 +32,10 @@ async function featureEnabled(productType: ProductType): Promise<boolean> {
   if (
     (productType === ProductType.Wine &&
       !(await wineFeatureEnabled.getValue())) ||
-    (productType === ProductType.Beer && !(await beerFeatureEnabled.getValue()))
+    (productType === ProductType.Beer &&
+      !(await beerFeatureEnabled.getValue())) ||
+    (productType === ProductType.Cider &&
+      !(await ciderFeatureEnabled.getValue()))
   ) {
     return false
   }

--- a/src/entrypoints/popup/index.html
+++ b/src/entrypoints/popup/index.html
@@ -51,6 +51,13 @@
                         <span class="slider"></span>
                     </label>
                 </div>
+                <div class="toggle-container">
+                    <span class="toggle-label">Cider &amp; blanddryck</span>
+                    <label class="switch">
+                        <input type="checkbox" id="cider" name="cider">
+                        <span class="slider"></span>
+                    </label>
+                </div>
                 <!-- <div class="toggle-container">
                     <span class="toggle-label">Sprit</span>
                     <label class="switch">

--- a/src/entrypoints/popup/main.ts
+++ b/src/entrypoints/popup/main.ts
@@ -1,6 +1,7 @@
 import { getLatestRelease, version } from '@/components/github'
 import {
   beerFeatureEnabled,
+  ciderFeatureEnabled,
   featuresEnabled,
   wineFeatureEnabled
 } from '@/components/settings'
@@ -54,6 +55,12 @@ async function setupToggles(): Promise<void> {
   beerToggle.checked = await beerFeatureEnabled.getValue()
   beerToggle.addEventListener('change', () => {
     void beerFeatureEnabled.setValue(beerToggle.checked)
+  })
+
+  const ciderToggle = document.getElementById('cider') as HTMLInputElement
+  ciderToggle.checked = await ciderFeatureEnabled.getValue()
+  ciderToggle.addEventListener('change', () => {
+    void ciderFeatureEnabled.setValue(ciderToggle.checked)
   })
 }
 


### PR DESCRIPTION
Replaces draft #97, rebased onto the current codebase and extended. Closes #2.

## Summary

- Inject compact rating badges (score + vote count) on sortiment list and search page product cards
- IntersectionObserver viewport-gating: only visible cards trigger requests (~6 per load instead of all 30); scrolling loads more
- Sequential 300 ms queue in ratingService serialises list requests to avoid rate limiting
- Cache key now uses the Systembolaget product ID (from the URL) instead of the product name, so list and product pages share cache entries
- e2e test for list-page badge injection

## Changes vs the draft

- Fixed extractProductId regex: product URLs end in `-<id>/`, not `/<id>/` (the draft regex never matched, so caching and list fetches were broken)
- List cards in the cider-blanddrycker category get badges too (integrates with #105; card gating reuses the shared featureEnabled helper)
- Reconciled with the per-product SPA request tracking and renamed i18n keys now on main

Stacked on #105 — merge order: #103 → #104 → #105 → this.

## Test plan

- [x] pnpm compile, pnpm lint clean
- [x] Full Playwright suite 11/11 (live API, product pages, live list-page badge test)
- [x] Verified live in browser: beer list shows badges with correct scores/votes, scrolling adds more (6 → 16), cider list gets badges, product pages unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)