### PR TITLE
fix: link to Vivino wine via vintage id, not generic wine id

### DIFF
--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -68,4 +68,39 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
     expect(result.status).toBe(RatingResultStatus.Uncertain);
     expect(result.link).toContain('vivino.com/search/wines');
   });
+
+  // Regression test: vivino.com/wines/{id} resolves by vintage id, not the
+  // generic wine id — using wine.id links to an unrelated wine (e.g. the
+  // Black Stallion Cabernet Sauvignon 2023's wine.id 1166077 resolves to a
+  // 2005 Bourgogne Pinot Noir instead).
+  test('builds the wine link from the vintage id, not the generic wine id', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            explore_vintage: {
+              matches: [
+                {
+                  vintage: {
+                    id: 173862896,
+                    name: 'Black Stallion Cabernet Sauvignon 2023',
+                    statistics: { ratings_average: 4.1, ratings_count: 54 },
+                    wine: {
+                      id: 1166077,
+                      seo_name: 'black-stallion-cabernet-sauvignon'
+                    }
+                  }
+                }
+              ]
+            }
+          })
+      } as Response)) as typeof fetch;
+
+    const result = await fetchRatingFromVivino(
+      'Black Stallion Napa Valley Cabernet Sauvignon 2023'
+    );
+
+    expect(result.link).toBe('https://www.vivino.com/wines/173862896');
+  });
 });

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -138,7 +138,7 @@ export async function fetchRatingFromVivino(
         const wineName = match.vintage.name
         const rating = match.vintage.statistics.ratings_average ?? 0
         const votes = match.vintage.statistics.ratings_count ?? 0
-        const link = `https://www.vivino.com/wines/${match.vintage.wine.id.toString()}`
+        const link = `https://www.vivino.com/wines/${match.vintage.id.toString()}`
         const similarityRate = stringSimilarity.compareTwoStrings(
           query,
           wineName


### PR DESCRIPTION
## Summary
- `vivino.com/wines/{id}` resolves by **vintage** id, not the generic `wine.id`. Using `wine.id` could send users to a completely unrelated wine while showing the correct rating/votes (those come from the matched vintage's own stats, so only the link was wrong).
- Confirmed live: for Black Stallion Napa Valley Cabernet Sauvignon 2023, `vivino.com/wines/1166077` (wine.id) redirected to an unrelated 2005 Bourgogne Pinot Noir, while `vivino.com/wines/173862896` (vintage.id) correctly resolves to the matched wine.
- Added a regression test (mocked fetch) asserting the link is built from `vintage.id`.

## Test plan
- [x] `pnpm compile`
- [x] `pnpm lint`
- [x] `pnpm build:chrome`
- [x] `pnpm test:api` — all 6 tests pass, including the new regression test