### PR TITLE
feat: suggest ranked alternatives when no rating match is confident

### DIFF
--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -103,4 +103,107 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
 
     expect(result.link).toBe('https://www.vivino.com/wines/173862896');
   });
+
+  test('returns ranked alternatives when no Vivino match is confident enough', async () => {
+    const vivinoMatch = (id: number, name: string, rating: number, votes: number) => ({
+      vintage: {
+        id,
+        name,
+        statistics: { ratings_average: rating, ratings_count: votes },
+        wine: { id: id + 1, seo_name: 'irrelevant' }
+      }
+    });
+
+    globalThis.fetch = (() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            explore_vintage: {
+              matches: [
+                // Similarities to the query (all below the 0.5 threshold):
+                // 0.200, 0.457, 0.167, 0.057 — so no auto-accept, and the
+                // ranked alternatives start with Falco Nero Riserva.
+                vivinoMatch(1, 'Torre Bianca Chardonnay', 4.0, 100),
+                vivinoMatch(2, 'Falco Nero Riserva', 4.4, 300),
+                vivinoMatch(3, 'Nero d Avola Sicilia', 3.8, 50),
+                vivinoMatch(4, 'Rioja Gran Reserva', 3.9, 80)
+              ]
+            }
+          })
+      } as Response)) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Torre del Falco Nero 2020');
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.link).toContain('vivino.com/search/wines');
+    // Capped at 3, ranked by similarity to the query.
+    expect(result.alternatives).toHaveLength(3);
+    expect(result.alternatives?.[0]).toEqual({
+      link: 'https://www.vivino.com/wines/2',
+      name: 'Falco Nero Riserva',
+      rating: 4.4,
+      votes: 300
+    });
+  });
+
+  test('returns no alternatives when the explore API has no matches', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ explore_vintage: { matches: [] } })
+      } as Response)) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Torre do Olivar');
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.alternatives).toBeUndefined();
+  });
+});
+
+test.describe('Untappd lookup misses (mocked fetch)', () => {
+  const realFetch = globalThis.fetch;
+
+  test.afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  test('returns ranked alternatives when no Untappd match is confident enough', async () => {
+    const untappdHit = (bid: number, name: string, rating: number, votes: number) => ({
+      beer_name: name,
+      beer_slug: `slug-${bid}`,
+      bid,
+      brewery_beer_name: `Brygghus ${name}`,
+      brewery_name: 'Brygghus',
+      rating_count: votes,
+      rating_score: rating
+    });
+
+    globalThis.fetch = (() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            hits: [
+              // Similarities to the query (all below the 0.2 threshold):
+              // 0.171, 0.194, 0.176, 0.118 — so no auto-accept, and the
+              // ranked alternatives start with Sommarlager.
+              untappdHit(1, 'Lagerhaus Dunkel', 3.2, 40),
+              untappdHit(2, 'Sommarlager', 3.9, 200),
+              untappdHit(3, 'Pilsner Urquell', 3.5, 90),
+              untappdHit(4, 'Citra Hazy Juice', 3.1, 10)
+            ]
+          })
+      } as Response)) as typeof fetch;
+
+    const result = await fetchRatingFromUntappd('Mystery Brew IPA');
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.link).toContain('untappd.com/search');
+    expect(result.alternatives).toHaveLength(3);
+    expect(result.alternatives?.[0].name).toBe('Sommarlager');
+    expect(result.alternatives?.[0].link).toBe(
+      'https://untappd.com/b/slug-2/2'
+    );
+  });
 });

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -15,6 +15,13 @@ export type BeerResponse = RatingResponse & {
   brewery: null | string
 }
 
+export interface RatingAlternative {
+  link: string
+  name: string
+  rating: number
+  votes: number
+}
+
 export interface RatingRequest {
   productId: string
   productName: string
@@ -22,6 +29,7 @@ export interface RatingRequest {
 }
 
 export interface RatingResponse {
+  alternatives?: RatingAlternative[]
   link: null | string
   name: null | string
   rating: number

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -2,6 +2,7 @@ import stringSimilarity from 'string-similarity'
 
 import {
   BeerResponse,
+  RatingAlternative,
   RatingResponse,
   RatingResultStatus,
   UntappdHit,
@@ -14,6 +15,10 @@ import {
 // public search-only credentials it ships to anonymous visitors.
 const UNTAPPD_ALGOLIA_APP_ID = '9WBO4RQ3HO'
 const UNTAPPD_ALGOLIA_SEARCH_KEY = '1d347324d67ec472bb7132c66aead485'
+
+// How many ranked candidates to surface as "did you mean" alternatives when
+// no match is confident enough to auto-select.
+const MAX_ALTERNATIVES = 3
 
 export async function fetchRatingFromUntappd(
   productName: string
@@ -52,14 +57,14 @@ export async function fetchRatingFromUntappd(
 
     type ScoredBeer = BeerResponse & { similarityRate: number }
 
-    const bestMatch = hits.reduce<null | ScoredBeer>(
-      (best, hit: UntappdHit) => {
+    const scored = hits
+      .map((hit: UntappdHit): ScoredBeer => {
         const similarityRate = Math.max(
           stringSimilarity.compareTwoStrings(productName, hit.beer_name),
           stringSimilarity.compareTwoStrings(productName, hit.brewery_beer_name)
         )
 
-        const current: ScoredBeer = {
+        return {
           brewery: hit.brewery_name,
           link: `https://untappd.com/b/${hit.beer_slug}/${hit.bid.toString()}`,
           name: hit.beer_name,
@@ -70,14 +75,14 @@ export async function fetchRatingFromUntappd(
           status: RatingResultStatus.Found,
           votes: hit.rating_count ?? 0
         }
+      })
+      .sort((a, b) => b.similarityRate - a.similarityRate)
 
-        return similarityRate > (best?.similarityRate ?? 0) ? current : best
-      },
-      null
-    )
+    const bestMatch = scored[0]
 
-    if (!bestMatch || bestMatch.similarityRate < 0.2) {
+    if (bestMatch.similarityRate < 0.2) {
       return {
+        alternatives: toAlternatives(scored),
         link: searchFallbackUrl,
         status: RatingResultStatus.Uncertain
       } as RatingResponse
@@ -133,8 +138,8 @@ export async function fetchRatingFromVivino(
 
     type ScoredWine = RatingResponse & { similarityRate: number }
 
-    const bestMatch = matches.reduce<null | ScoredWine>(
-      (best, match: VivinoMatch) => {
+    const scored = matches
+      .map((match: VivinoMatch): ScoredWine => {
         const wineName = match.vintage.name
         const rating = match.vintage.statistics.ratings_average ?? 0
         const votes = match.vintage.statistics.ratings_count ?? 0
@@ -144,7 +149,7 @@ export async function fetchRatingFromVivino(
           wineName
         )
 
-        const current: ScoredWine = {
+        return {
           link,
           name: wineName,
           rating,
@@ -152,18 +157,34 @@ export async function fetchRatingFromVivino(
           status: RatingResultStatus.Found,
           votes
         }
+      })
+      .sort((a, b) => b.similarityRate - a.similarityRate)
 
-        return similarityRate > (best?.similarityRate ?? 0) ? current : best
-      },
-      null
-    )
+    const bestMatch = scored[0]
 
-    if (!bestMatch || bestMatch.similarityRate < 0.5) {
-      return uncertainFallback
+    if (bestMatch.similarityRate < 0.5) {
+      return { ...uncertainFallback, alternatives: toAlternatives(scored) }
     }
 
     return bestMatch
   } catch {
     return uncertainFallback
   }
+}
+
+function toAlternatives(
+  scored: {
+    link: null | string
+    name: null | string
+    rating: number
+    votes: number
+  }[]
+): RatingAlternative[] {
+  return scored
+    .slice(0, MAX_ALTERNATIVES)
+    .filter(
+      (s): s is { link: string; name: string; rating: number; votes: number } =>
+        s.link !== null && s.name !== null
+    )
+    .map(({ link, name, rating, votes }) => ({ link, name, rating, votes }))
 }

--- a/src/components/domUtils.ts
+++ b/src/components/domUtils.ts
@@ -3,6 +3,7 @@ import { i18n } from '#i18n'
 import {
   BeerResponse,
   ProductType,
+  RatingAlternative,
   RatingResponse,
   RatingResultStatus
 } from '@/@types/types'
@@ -88,6 +89,46 @@ const STYLES = `
     color: #666;
     text-align: center;
     padding: 2px 0;
+  }
+  #${RATING_CONTAINER_ID} .bp-alt-list {
+    display: flex;
+    flex-direction: column;
+    margin-top: 6px;
+  }
+  #${RATING_CONTAINER_ID} .bp-alt-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    min-height: 44px;
+    padding: 6px 8px;
+    border-top: 1px solid #f0f0f0;
+    color: #1a1a1a;
+    text-decoration: none;
+  }
+  #${RATING_CONTAINER_ID} .bp-alt-item:hover,
+  #${RATING_CONTAINER_ID} .bp-alt-item:active {
+    background: #f6f6f6;
+  }
+  #${RATING_CONTAINER_ID} .bp-alt-name {
+    flex: 1;
+    min-width: 0;
+    font-size: 13px;
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  #${RATING_CONTAINER_ID} .bp-alt-score {
+    font-weight: 700;
+    font-size: 13px;
+    white-space: nowrap;
+  }
+  #${RATING_CONTAINER_ID} .bp-alt-votes {
+    color: #888;
+    font-size: 11px;
+    font-weight: 400;
   }
   #${RATING_CONTAINER_ID} .bp-spinner-wrap {
     display: flex;
@@ -231,12 +272,26 @@ export function setRating(
   ratingContainer.appendChild(footer)
 }
 
-export function setUncertain(productType: ProductType, link: null | string) {
+export function setUncertain(productType: ProductType, rating: RatingResponse) {
   const ratingContainer = getAndClearContainer()
+  const alternatives = rating.alternatives ?? []
 
   const message = document.createElement('div')
   message.className = 'bp-message'
-  message.innerText = i18n.t('uncertainMatch')
+  message.innerText =
+    alternatives.length > 0
+      ? `${i18n.t('didYouMean')}:`
+      : i18n.t('uncertainMatch')
+  ratingContainer.appendChild(message)
+
+  if (alternatives.length > 0) {
+    const list = document.createElement('div')
+    list.className = 'bp-alt-list'
+    for (const alternative of alternatives) {
+      list.appendChild(createAlternativeItem(alternative))
+    }
+    ratingContainer.appendChild(list)
+  }
 
   const linkLabel =
     productType === ProductType.Wine
@@ -247,9 +302,8 @@ export function setUncertain(productType: ProductType, link: null | string) {
   footer.className = 'bp-footer'
   footer.style.justifyContent = 'center'
   footer.style.marginTop = '6px'
-  footer.appendChild(createSourceLink(link, linkLabel))
+  footer.appendChild(createSourceLink(rating.link, linkLabel))
 
-  ratingContainer.appendChild(message)
   ratingContainer.appendChild(footer)
 }
 
@@ -263,6 +317,36 @@ export function showLoadingSpinner() {
     `
 
   ratingContainer.appendChild(spinner)
+}
+
+function createAlternativeItem(
+  alternative: RatingAlternative
+): HTMLAnchorElement {
+  const item = document.createElement('a')
+  item.className = 'bp-alt-item'
+  item.href = alternative.link
+  item.target = '_blank'
+  item.rel = 'noopener noreferrer'
+
+  const name = document.createElement('span')
+  name.className = 'bp-alt-name'
+  name.textContent = alternative.name
+
+  const score = document.createElement('span')
+  score.className = 'bp-alt-score'
+  // A score of 0 means the source has too few ratings to compute one yet.
+  score.textContent =
+    alternative.rating > 0 ? alternative.rating.toString() : 'N/A'
+  if (alternative.votes > 0) {
+    const votes = document.createElement('span')
+    votes.className = 'bp-alt-votes'
+    votes.textContent = ` (${alternative.votes.toString()})`
+    score.appendChild(votes)
+  }
+
+  item.appendChild(name)
+  item.appendChild(score)
+  return item
 }
 
 function createSourceLink(

--- a/src/components/domUtils.ts
+++ b/src/components/domUtils.ts
@@ -280,7 +280,7 @@ export function setUncertain(productType: ProductType, rating: RatingResponse) {
   message.className = 'bp-message'
   message.innerText =
     alternatives.length > 0
-      ? `${i18n.t('didYouMean')}:`
+      ? `${i18n.t('closestMatches')}:`
       : i18n.t('uncertainMatch')
   ratingContainer.appendChild(message)
 

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -83,7 +83,7 @@ function handleRating(productType: ProductType, rating: RatingResponse) {
       domUtils.setRating(productType, rating, rating.link)
       return
     case RatingResultStatus.Uncertain:
-      domUtils.setUncertain(productType, rating.link)
+      domUtils.setUncertain(productType, rating)
       return
     default:
       domUtils.setMessage(i18n.t('noMatch'))

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1,4 +1,5 @@
 brewery: Brewery
+didYouMean: Did you mean
 linkToUntappd: Link to Untappd
 linkToVivino: Link to Vivino
 loading: Loading...

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1,5 +1,5 @@
 brewery: Brewery
-didYouMean: Did you mean
+closestMatches: Closest matches
 linkToUntappd: Link to Untappd
 linkToVivino: Link to Vivino
 loading: Loading...

--- a/src/locales/sv.yml
+++ b/src/locales/sv.yml
@@ -1,5 +1,5 @@
 brewery: Bryggeri
-didYouMean: Menade du
+closestMatches: Närmaste träffar
 linkToUntappd: Länk till Untappd
 linkToVivino: Länk till Vivino
 loading: Laddar...

--- a/src/locales/sv.yml
+++ b/src/locales/sv.yml
@@ -1,4 +1,5 @@
 brewery: Bryggeri
+didYouMean: Menade du
 linkToUntappd: Länk till Untappd
 linkToVivino: Länk till Vivino
 loading: Laddar...


### PR DESCRIPTION
## Summary
- When the best Vivino/Untappd candidate falls below the similarity threshold, the card now shows a "Menade du:" / "Did you mean:" list with the top 3 ranked candidates (name + rating + votes), each linking directly to its Vivino/Untappd page — instead of only a generic search link. The search link is still shown below the list as a fallback.
- When the API returns zero candidates, behavior is unchanged (message + search link only).
- Mobile-first list styling: ≥44px tap targets, two-line name clamping, `:active` feedback for touch; hover styling is only an enhancement.
- Names are inserted via `textContent` (no HTML injection from external strings).

> **Stacked on #107** — based on `fix/vivino-vintage-link` so the two PRs don't conflict (this change rewrites the candidate-scoring block that #107's one-line fix touches). Merge #107 first (deleting its branch retargets this PR to `main` automatically).

## Test plan
- [x] `pnpm compile`
- [x] `pnpm lint`
- [x] `pnpm build:chrome`
- [x] Full Playwright suite (15 tests, incl. live-site e2e) passes
- [x] New mocked tests: Vivino alternatives ranked by similarity and capped at 3; Untappd alternatives with correct beer links; zero-match case returns no alternatives

🤖 Generated with [Claude Code](https://claude.com/claude-code)