### PR TITLE
feat: show Vivino label thumbnails on the rating card and alternatives

### DIFF
--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -147,6 +147,98 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
     });
   });
 
+  test('attaches label thumbnails as data URLs (page CSP blocks hotlinking)', async () => {
+    const exploreJson = {
+      explore_vintage: {
+        matches: [
+          {
+            vintage: {
+              id: 42,
+              image: {
+                variations: {
+                  label_medium: '//images.vivino.com/thumbs/fake_150x200.png'
+                }
+              },
+              name: 'Black Stallion Cabernet Sauvignon 2023',
+              statistics: { ratings_average: 4.1, ratings_count: 54 },
+              wine: { id: 43, seo_name: 'irrelevant' }
+            }
+          }
+        ]
+      }
+    };
+    const fakePng = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/explore/explore')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(exploreJson)
+        } as Response);
+      }
+      // Image request — must be the https-normalized thumbnail URL.
+      expect(url).toBe('https://images.vivino.com/thumbs/fake_150x200.png');
+      return Promise.resolve({
+        arrayBuffer: () => Promise.resolve(fakePng.buffer),
+        headers: new Headers({ 'content-type': 'image/png' }),
+        ok: true
+      } as unknown as Response);
+    }) as typeof fetch;
+
+    const result = await fetchRatingFromVivino(
+      'Black Stallion Napa Valley Cabernet Sauvignon 2023'
+    );
+
+    expect(result.status).toBe(RatingResultStatus.Found);
+    expect(result.imageDataUrl).toBe(
+      `data:image/png;base64,${Buffer.from(fakePng).toString('base64')}`
+    );
+  });
+
+  test('attaches thumbnails to alternatives when the match is uncertain', async () => {
+    const fakePng = new Uint8Array([1, 2, 3]);
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/explore/explore')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              explore_vintage: {
+                matches: [
+                  {
+                    vintage: {
+                      id: 7,
+                      image: {
+                        variations: {
+                          label_medium: '//images.vivino.com/thumbs/alt.png'
+                        }
+                      },
+                      name: 'Totally Unrelated Wine',
+                      statistics: { ratings_average: 4.0, ratings_count: 10 },
+                      wine: { id: 8, seo_name: 'x' }
+                    }
+                  }
+                ]
+              }
+            })
+        } as Response);
+      }
+      return Promise.resolve({
+        arrayBuffer: () => Promise.resolve(fakePng.buffer),
+        headers: new Headers({ 'content-type': 'image/png' }),
+        ok: true
+      } as unknown as Response);
+    }) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Zzz Qqq 1999');
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.alternatives).toHaveLength(1);
+    expect(result.alternatives?.[0].imageDataUrl).toMatch(/^data:image\/png;base64,/);
+  });
+
   test('returns no alternatives when the explore API has no matches', async () => {
     globalThis.fetch = (() =>
       Promise.resolve({

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -16,6 +16,7 @@ export type BeerResponse = RatingResponse & {
 }
 
 export interface RatingAlternative {
+  imageDataUrl?: string
   link: string
   name: string
   rating: number
@@ -30,6 +31,7 @@ export interface RatingRequest {
 
 export interface RatingResponse {
   alternatives?: RatingAlternative[]
+  imageDataUrl?: string
   link: null | string
   name: null | string
   rating: number
@@ -54,6 +56,12 @@ export interface UntappdSearchJSON {
 export interface VivinoMatch {
   vintage: {
     id: number
+    image?: {
+      location?: null | string
+      variations?: {
+        label_medium?: string
+      }
+    }
     name: string
     statistics: {
       ratings_average: null | number

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -136,7 +136,10 @@ export async function fetchRatingFromVivino(
       return uncertainFallback
     }
 
-    type ScoredWine = RatingResponse & { similarityRate: number }
+    type ScoredWine = RatingResponse & {
+      imageUrl?: string
+      similarityRate: number
+    }
 
     const scored = matches
       .map((match: VivinoMatch): ScoredWine => {
@@ -144,12 +147,17 @@ export async function fetchRatingFromVivino(
         const rating = match.vintage.statistics.ratings_average ?? 0
         const votes = match.vintage.statistics.ratings_count ?? 0
         const link = `https://www.vivino.com/wines/${match.vintage.id.toString()}`
+        const imageUrl = normalizeImageUrl(
+          match.vintage.image?.variations?.label_medium ??
+            match.vintage.image?.location
+        )
         const similarityRate = stringSimilarity.compareTwoStrings(
           query,
           wineName
         )
 
         return {
+          imageUrl,
           link,
           name: wineName,
           rating,
@@ -163,17 +171,60 @@ export async function fetchRatingFromVivino(
     const bestMatch = scored[0]
 
     if (bestMatch.similarityRate < 0.5) {
-      return { ...uncertainFallback, alternatives: toAlternatives(scored) }
+      const top = scored.slice(0, MAX_ALTERNATIVES)
+      await Promise.all(
+        top.map(async (wine) => {
+          wine.imageDataUrl = await fetchImageAsDataUrl(wine.imageUrl)
+        })
+      )
+      return { ...uncertainFallback, alternatives: toAlternatives(top) }
     }
 
+    bestMatch.imageDataUrl = await fetchImageAsDataUrl(bestMatch.imageUrl)
     return bestMatch
   } catch {
     return uncertainFallback
   }
 }
 
+// Fetched by the background script because the systembolaget.se page CSP
+// (img-src) blocks hotlinking Vivino's image hosts; a data: URL is allowed.
+async function fetchImageAsDataUrl(
+  url: string | undefined
+): Promise<string | undefined> {
+  if (!url) {
+    return undefined
+  }
+  try {
+    const response = await fetch(url)
+    if (!response.ok) {
+      return undefined
+    }
+    const contentType = response.headers.get('content-type') ?? 'image/png'
+    const bytes = new Uint8Array(await response.arrayBuffer())
+    let binary = ''
+    const chunkSize = 8192
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize))
+    }
+    return `data:${contentType};base64,${btoa(binary)}`
+  } catch {
+    return undefined
+  }
+}
+
+function normalizeImageUrl(
+  url: null | string | undefined
+): string | undefined {
+  if (!url) {
+    return undefined
+  }
+  return url.startsWith('//') ? `https:${url}` : url
+}
+
 function toAlternatives(
   scored: {
+    imageDataUrl?: string
     link: null | string
     name: null | string
     rating: number
@@ -182,9 +233,9 @@ function toAlternatives(
 ): RatingAlternative[] {
   return scored
     .slice(0, MAX_ALTERNATIVES)
-    .filter(
-      (s): s is { link: string; name: string; rating: number; votes: number } =>
-        s.link !== null && s.name !== null
+    .flatMap(({ imageDataUrl, link, name, rating, votes }) =>
+      link !== null && name !== null
+        ? [{ imageDataUrl, link, name, rating, votes }]
+        : []
     )
-    .map(({ link, name, rating, votes }) => ({ link, name, rating, votes }))
 }

--- a/src/components/domUtils.ts
+++ b/src/components/domUtils.ts
@@ -130,6 +130,18 @@ const STYLES = `
     font-size: 11px;
     font-weight: 400;
   }
+  #${RATING_CONTAINER_ID} .bp-thumb {
+    width: 36px;
+    height: 48px;
+    object-fit: contain;
+    flex-shrink: 0;
+  }
+  #${RATING_CONTAINER_ID} .bp-alt-thumb {
+    width: 28px;
+    height: 38px;
+    object-fit: contain;
+    flex-shrink: 0;
+  }
   #${RATING_CONTAINER_ID} .bp-spinner-wrap {
     display: flex;
     justify-content: center;
@@ -247,6 +259,9 @@ export function setRating(
         ${svg}
         ${scoreHtml}
       `
+  if (rating.imageDataUrl) {
+    ratingRow.prepend(createThumbnail(rating.imageDataUrl, 'bp-thumb'))
+  }
 
   const meta = document.createElement('div')
   meta.className = 'bp-meta'
@@ -328,6 +343,10 @@ function createAlternativeItem(
   item.target = '_blank'
   item.rel = 'noopener noreferrer'
 
+  if (alternative.imageDataUrl) {
+    item.appendChild(createThumbnail(alternative.imageDataUrl, 'bp-alt-thumb'))
+  }
+
   const name = document.createElement('span')
   name.className = 'bp-alt-name'
   name.textContent = alternative.name
@@ -366,6 +385,14 @@ function createSourceLink(
     `<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7M9 7h8v8"/></svg>`
   )
   return linkElement
+}
+
+function createThumbnail(dataUrl: string, className: string): HTMLImageElement {
+  const img = document.createElement('img')
+  img.className = className
+  img.src = dataUrl
+  img.alt = ''
+  return img
 }
 
 function ensureStyles(): void {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -36,12 +36,15 @@ export default defineConfig({
     host_permissions: [
       'https://www.systembolaget.se/*',
       'https://www.vivino.com/*',
+      // Vivino serves label/bottle thumbnails from separate image hosts
+      'https://images.vivino.com/*',
+      'https://thumbs.vivino.com/*',
       'https://untappd.com/*',
       // Untappd's Algolia search index, used for beer lookups
       'https://9wbo4rq3ho-dsn.algolia.net/*'
     ],
     content_security_policy: {
-      extension_pages: `script-src 'self'; object-src 'self'; connect-src 'self' https://www.vivino.com https://untappd.com https://9wbo4rq3ho-dsn.algolia.net${isProduction ? '' : ' ws://localhost:3000/'};`
+      extension_pages: `script-src 'self'; object-src 'self'; connect-src 'self' https://www.vivino.com https://images.vivino.com https://thumbs.vivino.com https://untappd.com https://9wbo4rq3ho-dsn.algolia.net${isProduction ? '' : ' ws://localhost:3000/'};`
     },
     browser_specific_settings: {
       gecko: {


### PR DESCRIPTION
## Summary
- The rating card now shows the matched wine's label thumbnail next to the stars, and each "Menade du" alternative row gets a smaller thumbnail — making it much easier to recognize the right wine at a glance.
- **CSP workaround:** Systembolaget's page CSP (`img-src`) blocks hotlinking Vivino's image hosts, but allows `data:` URLs. The background script (not subject to page CSP) fetches the thumbnail and passes a base64 `data:` URL to the content script. Verified against the live site.
- Mobile-first per earlier discussion: thumbnails are always visible (no hover-reveal, which wouldn't work on touch). Fixed-size, `object-fit: contain`, omitted entirely when Vivino has no image or the fetch fails — never breaks the rating.
- Thumbnails ride along in the existing 1-day rating cache, so repeat visits don't refetch.
- Manifest: adds `images.vivino.com` + `thumbs.vivino.com` to `host_permissions` and extension CSP `connect-src`.

Scope note: Vivino/wine only — Untappd beer labels can follow the same pattern in a later PR if wanted.

> **Stacked on #108** (which is stacked on #107). Merge order: #107 → #108 → this. Deleting each branch on merge auto-retargets the next PR.

## Test plan
- [x] `pnpm compile`, `pnpm lint`, `pnpm build:chrome`
- [x] Full Playwright suite passes (17 tests incl. live-site e2e)
- [x] New mocked tests: found-path thumbnail becomes a correct base64 `data:` URL with https-normalized fetch URL; uncertain-path alternatives each carry `imageDataUrl`
- [x] Visually verified on the live Black Stallion product page — label thumbnail renders inside the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)