### PR TITLE
feat: land alternatives picker + Vivino thumbnails on main

### DIFF
--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -68,4 +68,39 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
     expect(result.status).toBe(RatingResultStatus.Uncertain);
     expect(result.link).toContain('vivino.com/search/wines');
   });
+
+  // Regression test: vivino.com/wines/{id} resolves by vintage id, not the
+  // generic wine id — using wine.id links to an unrelated wine (e.g. the
+  // Black Stallion Cabernet Sauvignon 2023's wine.id 1166077 resolves to a
+  // 2005 Bourgogne Pinot Noir instead).
+  test('builds the wine link from the vintage id, not the generic wine id', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            explore_vintage: {
+              matches: [
+                {
+                  vintage: {
+                    id: 173862896,
+                    name: 'Black Stallion Cabernet Sauvignon 2023',
+                    statistics: { ratings_average: 4.1, ratings_count: 54 },
+                    wine: {
+                      id: 1166077,
+                      seo_name: 'black-stallion-cabernet-sauvignon'
+                    }
+                  }
+                }
+              ]
+            }
+          })
+      } as Response)) as typeof fetch;
+
+    const result = await fetchRatingFromVivino(
+      'Black Stallion Napa Valley Cabernet Sauvignon 2023'
+    );
+
+    expect(result.link).toBe('https://www.vivino.com/wines/173862896');
+  });
 });

--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -358,39 +358,4 @@ test.describe('Untappd lookup misses (mocked fetch)', () => {
       'https://untappd.com/b/slug-2/2'
     );
   });
-
-  // Regression test: vivino.com/wines/{id} resolves by vintage id, not the
-  // generic wine id — using wine.id links to an unrelated wine (e.g. the
-  // Black Stallion Cabernet Sauvignon 2023's wine.id 1166077 resolves to a
-  // 2005 Bourgogne Pinot Noir instead).
-  test('builds the wine link from the vintage id, not the generic wine id', async () => {
-    globalThis.fetch = (() =>
-      Promise.resolve({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            explore_vintage: {
-              matches: [
-                {
-                  vintage: {
-                    id: 173862896,
-                    name: 'Black Stallion Cabernet Sauvignon 2023',
-                    statistics: { ratings_average: 4.1, ratings_count: 54 },
-                    wine: {
-                      id: 1166077,
-                      seo_name: 'black-stallion-cabernet-sauvignon'
-                    }
-                  }
-                }
-              ]
-            }
-          })
-      } as Response)) as typeof fetch;
-
-    const result = await fetchRatingFromVivino(
-      'Black Stallion Napa Valley Cabernet Sauvignon 2023'
-    );
-
-    expect(result.link).toBe('https://www.vivino.com/wines/173862896');
-  });
 });

--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -57,6 +57,8 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
     expect(result.link).toBe(
       'https://www.vivino.com/search/wines?q=Torre%20do%20Olivar'
     );
+    // A genuine no-match is definitive and may be cached.
+    expect(result.transient).toBeUndefined();
   });
 
   test('returns Uncertain with a search link when the request fails', async () => {
@@ -67,6 +69,18 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
 
     expect(result.status).toBe(RatingResultStatus.Uncertain);
     expect(result.link).toContain('vivino.com/search/wines');
+    // Network failures are transient and must not be cached for a day.
+    expect(result.transient).toBe(true);
+  });
+
+  test('marks rate-limited responses transient so they are not cached', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve({ ok: false, status: 429 } as Response)) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Some Wine');
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.transient).toBe(true);
   });
 
   // Regression test: vivino.com/wines/{id} resolves by vintage id, not the

--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -103,4 +103,107 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
 
     expect(result.link).toBe('https://www.vivino.com/wines/173862896');
   });
+
+  test('returns ranked alternatives when no Vivino match is confident enough', async () => {
+    const vivinoMatch = (id: number, name: string, rating: number, votes: number) => ({
+      vintage: {
+        id,
+        name,
+        statistics: { ratings_average: rating, ratings_count: votes },
+        wine: { id: id + 1, seo_name: 'irrelevant' }
+      }
+    });
+
+    globalThis.fetch = (() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            explore_vintage: {
+              matches: [
+                // Similarities to the query (all below the 0.5 threshold):
+                // 0.200, 0.457, 0.167, 0.057 — so no auto-accept, and the
+                // ranked alternatives start with Falco Nero Riserva.
+                vivinoMatch(1, 'Torre Bianca Chardonnay', 4.0, 100),
+                vivinoMatch(2, 'Falco Nero Riserva', 4.4, 300),
+                vivinoMatch(3, 'Nero d Avola Sicilia', 3.8, 50),
+                vivinoMatch(4, 'Rioja Gran Reserva', 3.9, 80)
+              ]
+            }
+          })
+      } as Response)) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Torre del Falco Nero 2020');
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.link).toContain('vivino.com/search/wines');
+    // Capped at 3, ranked by similarity to the query.
+    expect(result.alternatives).toHaveLength(3);
+    expect(result.alternatives?.[0]).toEqual({
+      link: 'https://www.vivino.com/wines/2',
+      name: 'Falco Nero Riserva',
+      rating: 4.4,
+      votes: 300
+    });
+  });
+
+  test('returns no alternatives when the explore API has no matches', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ explore_vintage: { matches: [] } })
+      } as Response)) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Torre do Olivar');
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.alternatives).toBeUndefined();
+  });
+});
+
+test.describe('Untappd lookup misses (mocked fetch)', () => {
+  const realFetch = globalThis.fetch;
+
+  test.afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  test('returns ranked alternatives when no Untappd match is confident enough', async () => {
+    const untappdHit = (bid: number, name: string, rating: number, votes: number) => ({
+      beer_name: name,
+      beer_slug: `slug-${bid}`,
+      bid,
+      brewery_beer_name: `Brygghus ${name}`,
+      brewery_name: 'Brygghus',
+      rating_count: votes,
+      rating_score: rating
+    });
+
+    globalThis.fetch = (() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            hits: [
+              // Similarities to the query (all below the 0.2 threshold):
+              // 0.171, 0.194, 0.176, 0.118 — so no auto-accept, and the
+              // ranked alternatives start with Sommarlager.
+              untappdHit(1, 'Lagerhaus Dunkel', 3.2, 40),
+              untappdHit(2, 'Sommarlager', 3.9, 200),
+              untappdHit(3, 'Pilsner Urquell', 3.5, 90),
+              untappdHit(4, 'Citra Hazy Juice', 3.1, 10)
+            ]
+          })
+      } as Response)) as typeof fetch;
+
+    const result = await fetchRatingFromUntappd('Mystery Brew IPA');
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.link).toContain('untappd.com/search');
+    expect(result.alternatives).toHaveLength(3);
+    expect(result.alternatives?.[0].name).toBe('Sommarlager');
+    expect(result.alternatives?.[0].link).toBe(
+      'https://untappd.com/b/slug-2/2'
+    );
+  });
 });

--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -239,6 +239,52 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
     expect(result.alternatives?.[0].imageDataUrl).toMatch(/^data:image\/png;base64,/);
   });
 
+  test('skips thumbnail downloads when includeImage is false (list pages)', async () => {
+    const imageRequests: string[] = [];
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/explore/explore')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              explore_vintage: {
+                matches: [
+                  {
+                    vintage: {
+                      id: 42,
+                      image: {
+                        variations: {
+                          label_medium: '//images.vivino.com/thumbs/x.png'
+                        }
+                      },
+                      name: 'Black Stallion Cabernet Sauvignon 2023',
+                      statistics: { ratings_average: 4.1, ratings_count: 54 },
+                      wine: { id: 43, seo_name: 'irrelevant' }
+                    }
+                  }
+                ]
+              }
+            })
+        } as Response);
+      }
+      imageRequests.push(url);
+      return Promise.reject(new Error('unexpected image fetch'));
+    }) as typeof fetch;
+
+    const result = await fetchRatingFromVivino(
+      'Black Stallion Napa Valley Cabernet Sauvignon 2023',
+      false
+    );
+
+    expect(result.status).toBe(RatingResultStatus.Found);
+    expect(result.imageDataUrl).toBeUndefined();
+    expect(imageRequests).toHaveLength(0);
+    // Internal scoring fields must not leak into the response/cache.
+    expect(result).not.toHaveProperty('similarityRate');
+    expect(result).not.toHaveProperty('imageUrl');
+  });
+
   test('returns no alternatives when the explore API has no matches', async () => {
     globalThis.fetch = (() =>
       Promise.resolve({

--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -147,6 +147,98 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
     });
   });
 
+  test('attaches label thumbnails as data URLs (page CSP blocks hotlinking)', async () => {
+    const exploreJson = {
+      explore_vintage: {
+        matches: [
+          {
+            vintage: {
+              id: 42,
+              image: {
+                variations: {
+                  label_medium: '//images.vivino.com/thumbs/fake_150x200.png'
+                }
+              },
+              name: 'Black Stallion Cabernet Sauvignon 2023',
+              statistics: { ratings_average: 4.1, ratings_count: 54 },
+              wine: { id: 43, seo_name: 'irrelevant' }
+            }
+          }
+        ]
+      }
+    };
+    const fakePng = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/explore/explore')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(exploreJson)
+        } as Response);
+      }
+      // Image request — must be the https-normalized thumbnail URL.
+      expect(url).toBe('https://images.vivino.com/thumbs/fake_150x200.png');
+      return Promise.resolve({
+        arrayBuffer: () => Promise.resolve(fakePng.buffer),
+        headers: new Headers({ 'content-type': 'image/png' }),
+        ok: true
+      } as unknown as Response);
+    }) as typeof fetch;
+
+    const result = await fetchRatingFromVivino(
+      'Black Stallion Napa Valley Cabernet Sauvignon 2023'
+    );
+
+    expect(result.status).toBe(RatingResultStatus.Found);
+    expect(result.imageDataUrl).toBe(
+      `data:image/png;base64,${Buffer.from(fakePng).toString('base64')}`
+    );
+  });
+
+  test('attaches thumbnails to alternatives when the match is uncertain', async () => {
+    const fakePng = new Uint8Array([1, 2, 3]);
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/explore/explore')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              explore_vintage: {
+                matches: [
+                  {
+                    vintage: {
+                      id: 7,
+                      image: {
+                        variations: {
+                          label_medium: '//images.vivino.com/thumbs/alt.png'
+                        }
+                      },
+                      name: 'Totally Unrelated Wine',
+                      statistics: { ratings_average: 4.0, ratings_count: 10 },
+                      wine: { id: 8, seo_name: 'x' }
+                    }
+                  }
+                ]
+              }
+            })
+        } as Response);
+      }
+      return Promise.resolve({
+        arrayBuffer: () => Promise.resolve(fakePng.buffer),
+        headers: new Headers({ 'content-type': 'image/png' }),
+        ok: true
+      } as unknown as Response);
+    }) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Zzz Qqq 1999');
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.alternatives).toHaveLength(1);
+    expect(result.alternatives?.[0].imageDataUrl).toMatch(/^data:image\/png;base64,/);
+  });
+
   test('returns no alternatives when the explore API has no matches', async () => {
     globalThis.fetch = (() =>
       Promise.resolve({

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -15,6 +15,13 @@ export type BeerResponse = RatingResponse & {
   brewery: null | string
 }
 
+export interface RatingAlternative {
+  link: string
+  name: string
+  rating: number
+  votes: number
+}
+
 export interface RatingRequest {
   productId: string
   productName: string
@@ -22,6 +29,7 @@ export interface RatingRequest {
 }
 
 export interface RatingResponse {
+  alternatives?: RatingAlternative[]
   link: null | string
   name: null | string
   rating: number

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -24,6 +24,9 @@ export interface RatingAlternative {
 }
 
 export interface RatingRequest {
+  // List-page badges never render images, so they skip the thumbnail
+  // download; product pages opt in.
+  includeImage?: boolean
   productId: string
   productName: string
   query: ProductType

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -39,6 +39,10 @@ export interface RatingResponse {
   name: null | string
   rating: number
   status: RatingResultStatus
+  // Set when the result reflects a transient failure (rate limit, network
+  // error) rather than a definitive lookup miss — never cached, so the next
+  // visit retries instead of pinning a wrong answer for a day.
+  transient?: boolean
   votes: number
 }
 

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -16,6 +16,7 @@ export type BeerResponse = RatingResponse & {
 }
 
 export interface RatingAlternative {
+  imageDataUrl?: string
   link: string
   name: string
   rating: number
@@ -30,6 +31,7 @@ export interface RatingRequest {
 
 export interface RatingResponse {
   alternatives?: RatingAlternative[]
+  imageDataUrl?: string
   link: null | string
   name: null | string
   rating: number
@@ -54,6 +56,12 @@ export interface UntappdSearchJSON {
 export interface VivinoMatch {
   vintage: {
     id: number
+    image?: {
+      location?: null | string
+      variations?: {
+        label_medium?: string
+      }
+    }
     name: string
     statistics: {
       ratings_average: null | number

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -2,6 +2,7 @@ import stringSimilarity from 'string-similarity'
 
 import {
   BeerResponse,
+  RatingAlternative,
   RatingResponse,
   RatingResultStatus,
   UntappdHit,
@@ -14,6 +15,10 @@ import {
 // public search-only credentials it ships to anonymous visitors.
 const UNTAPPD_ALGOLIA_APP_ID = '9WBO4RQ3HO'
 const UNTAPPD_ALGOLIA_SEARCH_KEY = '1d347324d67ec472bb7132c66aead485'
+
+// How many ranked candidates to surface as "did you mean" alternatives when
+// no match is confident enough to auto-select.
+const MAX_ALTERNATIVES = 3
 
 export async function fetchRatingFromUntappd(
   productName: string
@@ -52,14 +57,14 @@ export async function fetchRatingFromUntappd(
 
     type ScoredBeer = BeerResponse & { similarityRate: number }
 
-    const bestMatch = hits.reduce<null | ScoredBeer>(
-      (best, hit: UntappdHit) => {
+    const scored = hits
+      .map((hit: UntappdHit): ScoredBeer => {
         const similarityRate = Math.max(
           stringSimilarity.compareTwoStrings(productName, hit.beer_name),
           stringSimilarity.compareTwoStrings(productName, hit.brewery_beer_name)
         )
 
-        const current: ScoredBeer = {
+        return {
           brewery: hit.brewery_name,
           link: `https://untappd.com/b/${hit.beer_slug}/${hit.bid.toString()}`,
           name: hit.beer_name,
@@ -70,14 +75,14 @@ export async function fetchRatingFromUntappd(
           status: RatingResultStatus.Found,
           votes: hit.rating_count ?? 0
         }
+      })
+      .sort((a, b) => b.similarityRate - a.similarityRate)
 
-        return similarityRate > (best?.similarityRate ?? 0) ? current : best
-      },
-      null
-    )
+    const bestMatch = scored[0]
 
-    if (!bestMatch || bestMatch.similarityRate < 0.2) {
+    if (bestMatch.similarityRate < 0.2) {
       return {
+        alternatives: toAlternatives(scored),
         link: searchFallbackUrl,
         status: RatingResultStatus.Uncertain
       } as RatingResponse
@@ -133,8 +138,8 @@ export async function fetchRatingFromVivino(
 
     type ScoredWine = RatingResponse & { similarityRate: number }
 
-    const bestMatch = matches.reduce<null | ScoredWine>(
-      (best, match: VivinoMatch) => {
+    const scored = matches
+      .map((match: VivinoMatch): ScoredWine => {
         const wineName = match.vintage.name
         const rating = match.vintage.statistics.ratings_average ?? 0
         const votes = match.vintage.statistics.ratings_count ?? 0
@@ -144,7 +149,7 @@ export async function fetchRatingFromVivino(
           wineName
         )
 
-        const current: ScoredWine = {
+        return {
           link,
           name: wineName,
           rating,
@@ -152,18 +157,34 @@ export async function fetchRatingFromVivino(
           status: RatingResultStatus.Found,
           votes
         }
+      })
+      .sort((a, b) => b.similarityRate - a.similarityRate)
 
-        return similarityRate > (best?.similarityRate ?? 0) ? current : best
-      },
-      null
-    )
+    const bestMatch = scored[0]
 
-    if (!bestMatch || bestMatch.similarityRate < 0.5) {
-      return uncertainFallback
+    if (bestMatch.similarityRate < 0.5) {
+      return { ...uncertainFallback, alternatives: toAlternatives(scored) }
     }
 
     return bestMatch
   } catch {
     return uncertainFallback
   }
+}
+
+function toAlternatives(
+  scored: {
+    link: null | string
+    name: null | string
+    rating: number
+    votes: number
+  }[]
+): RatingAlternative[] {
+  return scored
+    .slice(0, MAX_ALTERNATIVES)
+    .filter(
+      (s): s is { link: string; name: string; rating: number; votes: number } =>
+        s.link !== null && s.name !== null
+    )
+    .map(({ link, name, rating, votes }) => ({ link, name, rating, votes }))
 }

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -138,7 +138,7 @@ export async function fetchRatingFromVivino(
         const wineName = match.vintage.name
         const rating = match.vintage.statistics.ratings_average ?? 0
         const votes = match.vintage.statistics.ratings_count ?? 0
-        const link = `https://www.vivino.com/wines/${match.vintage.wine.id.toString()}`
+        const link = `https://www.vivino.com/wines/${match.vintage.id.toString()}`
         const similarityRate = stringSimilarity.compareTwoStrings(
           query,
           wineName

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -136,7 +136,10 @@ export async function fetchRatingFromVivino(
       return uncertainFallback
     }
 
-    type ScoredWine = RatingResponse & { similarityRate: number }
+    type ScoredWine = RatingResponse & {
+      imageUrl?: string
+      similarityRate: number
+    }
 
     const scored = matches
       .map((match: VivinoMatch): ScoredWine => {
@@ -144,12 +147,17 @@ export async function fetchRatingFromVivino(
         const rating = match.vintage.statistics.ratings_average ?? 0
         const votes = match.vintage.statistics.ratings_count ?? 0
         const link = `https://www.vivino.com/wines/${match.vintage.id.toString()}`
+        const imageUrl = normalizeImageUrl(
+          match.vintage.image?.variations?.label_medium ??
+            match.vintage.image?.location
+        )
         const similarityRate = stringSimilarity.compareTwoStrings(
           query,
           wineName
         )
 
         return {
+          imageUrl,
           link,
           name: wineName,
           rating,
@@ -163,17 +171,60 @@ export async function fetchRatingFromVivino(
     const bestMatch = scored[0]
 
     if (bestMatch.similarityRate < 0.5) {
-      return { ...uncertainFallback, alternatives: toAlternatives(scored) }
+      const top = scored.slice(0, MAX_ALTERNATIVES)
+      await Promise.all(
+        top.map(async (wine) => {
+          wine.imageDataUrl = await fetchImageAsDataUrl(wine.imageUrl)
+        })
+      )
+      return { ...uncertainFallback, alternatives: toAlternatives(top) }
     }
 
+    bestMatch.imageDataUrl = await fetchImageAsDataUrl(bestMatch.imageUrl)
     return bestMatch
   } catch {
     return uncertainFallback
   }
 }
 
+// Fetched by the background script because the systembolaget.se page CSP
+// (img-src) blocks hotlinking Vivino's image hosts; a data: URL is allowed.
+async function fetchImageAsDataUrl(
+  url: string | undefined
+): Promise<string | undefined> {
+  if (!url) {
+    return undefined
+  }
+  try {
+    const response = await fetch(url)
+    if (!response.ok) {
+      return undefined
+    }
+    const contentType = response.headers.get('content-type') ?? 'image/png'
+    const bytes = new Uint8Array(await response.arrayBuffer())
+    let binary = ''
+    const chunkSize = 8192
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize))
+    }
+    return `data:${contentType};base64,${btoa(binary)}`
+  } catch {
+    return undefined
+  }
+}
+
+function normalizeImageUrl(
+  url: null | string | undefined
+): string | undefined {
+  if (!url) {
+    return undefined
+  }
+  return url.startsWith('//') ? `https:${url}` : url
+}
+
 function toAlternatives(
   scored: {
+    imageDataUrl?: string
     link: null | string
     name: null | string
     rating: number
@@ -182,9 +233,9 @@ function toAlternatives(
 ): RatingAlternative[] {
   return scored
     .slice(0, MAX_ALTERNATIVES)
-    .filter(
-      (s): s is { link: string; name: string; rating: number; votes: number } =>
-        s.link !== null && s.name !== null
+    .flatMap(({ imageDataUrl, link, name, rating, votes }) =>
+      link !== null && name !== null
+        ? [{ imageDataUrl, link, name, rating, votes }]
+        : []
     )
-    .map(({ link, name, rating, votes }) => ({ link, name, rating, votes }))
 }

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -20,6 +20,9 @@ const UNTAPPD_ALGOLIA_SEARCH_KEY = '1d347324d67ec472bb7132c66aead485'
 // no match is confident enough to auto-select.
 const MAX_ALTERNATIVES = 3
 
+// A hung image download must not hold up the rating itself.
+const IMAGE_FETCH_TIMEOUT_MS = 4000
+
 export async function fetchRatingFromUntappd(
   productName: string
 ): Promise<RatingResponse> {
@@ -88,14 +91,23 @@ export async function fetchRatingFromUntappd(
       } as RatingResponse
     }
 
-    return bestMatch
+    // Return only the response contract — similarityRate is internal.
+    return {
+      brewery: bestMatch.brewery,
+      link: bestMatch.link,
+      name: bestMatch.name,
+      rating: bestMatch.rating,
+      status: bestMatch.status,
+      votes: bestMatch.votes
+    } as BeerResponse
   } catch {
     return { status: RatingResultStatus.NotFound } as RatingResponse
   }
 }
 
 export async function fetchRatingFromVivino(
-  query: string
+  query: string,
+  includeImage = true
 ): Promise<RatingResponse> {
   const params = new URLSearchParams({
     facets: 'false',
@@ -172,16 +184,27 @@ export async function fetchRatingFromVivino(
 
     if (bestMatch.similarityRate < 0.5) {
       const top = scored.slice(0, MAX_ALTERNATIVES)
-      await Promise.all(
-        top.map(async (wine) => {
-          wine.imageDataUrl = await fetchImageAsDataUrl(wine.imageUrl)
-        })
-      )
+      if (includeImage) {
+        await Promise.all(
+          top.map(async (wine) => {
+            wine.imageDataUrl = await fetchImageAsDataUrl(wine.imageUrl)
+          })
+        )
+      }
       return { ...uncertainFallback, alternatives: toAlternatives(top) }
     }
 
-    bestMatch.imageDataUrl = await fetchImageAsDataUrl(bestMatch.imageUrl)
-    return bestMatch
+    // Return only the response contract — similarityRate/imageUrl are internal.
+    return {
+      imageDataUrl: includeImage
+        ? await fetchImageAsDataUrl(bestMatch.imageUrl)
+        : undefined,
+      link: bestMatch.link,
+      name: bestMatch.name,
+      rating: bestMatch.rating,
+      status: bestMatch.status,
+      votes: bestMatch.votes
+    }
   } catch {
     return uncertainFallback
   }
@@ -196,7 +219,9 @@ async function fetchImageAsDataUrl(
     return undefined
   }
   try {
-    const response = await fetch(url)
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(IMAGE_FETCH_TIMEOUT_MS)
+    })
     if (!response.ok) {
       return undefined
     }

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -137,8 +137,10 @@ export async function fetchRatingFromVivino(
       }
     })
 
+    // HTTP errors (429 rate limit, 5xx) are transient — show the search-link
+    // fallback but don't let it get cached as a definitive miss.
     if (!response.ok) {
-      return uncertainFallback
+      return { ...uncertainFallback, transient: true }
     }
 
     const data = (await response.json()) as VivinoResponseJSON
@@ -206,7 +208,7 @@ export async function fetchRatingFromVivino(
       votes: bestMatch.votes
     }
   } catch {
-    return uncertainFallback
+    return { ...uncertainFallback, transient: true }
   }
 }
 

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -240,9 +240,7 @@ async function fetchImageAsDataUrl(
   }
 }
 
-function normalizeImageUrl(
-  url: null | string | undefined
-): string | undefined {
+function normalizeImageUrl(url: null | string | undefined): string | undefined {
   if (!url) {
     return undefined
   }

--- a/src/components/domUtils.ts
+++ b/src/components/domUtils.ts
@@ -3,6 +3,7 @@ import { i18n } from '#i18n'
 import {
   BeerResponse,
   ProductType,
+  RatingAlternative,
   RatingResponse,
   RatingResultStatus
 } from '@/@types/types'
@@ -88,6 +89,46 @@ const STYLES = `
     color: #666;
     text-align: center;
     padding: 2px 0;
+  }
+  #${RATING_CONTAINER_ID} .bp-alt-list {
+    display: flex;
+    flex-direction: column;
+    margin-top: 6px;
+  }
+  #${RATING_CONTAINER_ID} .bp-alt-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    min-height: 44px;
+    padding: 6px 8px;
+    border-top: 1px solid #f0f0f0;
+    color: #1a1a1a;
+    text-decoration: none;
+  }
+  #${RATING_CONTAINER_ID} .bp-alt-item:hover,
+  #${RATING_CONTAINER_ID} .bp-alt-item:active {
+    background: #f6f6f6;
+  }
+  #${RATING_CONTAINER_ID} .bp-alt-name {
+    flex: 1;
+    min-width: 0;
+    font-size: 13px;
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  #${RATING_CONTAINER_ID} .bp-alt-score {
+    font-weight: 700;
+    font-size: 13px;
+    white-space: nowrap;
+  }
+  #${RATING_CONTAINER_ID} .bp-alt-votes {
+    color: #888;
+    font-size: 11px;
+    font-weight: 400;
   }
   #${RATING_CONTAINER_ID} .bp-spinner-wrap {
     display: flex;
@@ -231,12 +272,26 @@ export function setRating(
   ratingContainer.appendChild(footer)
 }
 
-export function setUncertain(productType: ProductType, link: null | string) {
+export function setUncertain(productType: ProductType, rating: RatingResponse) {
   const ratingContainer = getAndClearContainer()
+  const alternatives = rating.alternatives ?? []
 
   const message = document.createElement('div')
   message.className = 'bp-message'
-  message.innerText = i18n.t('uncertainMatch')
+  message.innerText =
+    alternatives.length > 0
+      ? `${i18n.t('didYouMean')}:`
+      : i18n.t('uncertainMatch')
+  ratingContainer.appendChild(message)
+
+  if (alternatives.length > 0) {
+    const list = document.createElement('div')
+    list.className = 'bp-alt-list'
+    for (const alternative of alternatives) {
+      list.appendChild(createAlternativeItem(alternative))
+    }
+    ratingContainer.appendChild(list)
+  }
 
   const linkLabel =
     productType === ProductType.Wine
@@ -247,9 +302,8 @@ export function setUncertain(productType: ProductType, link: null | string) {
   footer.className = 'bp-footer'
   footer.style.justifyContent = 'center'
   footer.style.marginTop = '6px'
-  footer.appendChild(createSourceLink(link, linkLabel))
+  footer.appendChild(createSourceLink(rating.link, linkLabel))
 
-  ratingContainer.appendChild(message)
   ratingContainer.appendChild(footer)
 }
 
@@ -263,6 +317,36 @@ export function showLoadingSpinner() {
     `
 
   ratingContainer.appendChild(spinner)
+}
+
+function createAlternativeItem(
+  alternative: RatingAlternative
+): HTMLAnchorElement {
+  const item = document.createElement('a')
+  item.className = 'bp-alt-item'
+  item.href = alternative.link
+  item.target = '_blank'
+  item.rel = 'noopener noreferrer'
+
+  const name = document.createElement('span')
+  name.className = 'bp-alt-name'
+  name.textContent = alternative.name
+
+  const score = document.createElement('span')
+  score.className = 'bp-alt-score'
+  // A score of 0 means the source has too few ratings to compute one yet.
+  score.textContent =
+    alternative.rating > 0 ? alternative.rating.toString() : 'N/A'
+  if (alternative.votes > 0) {
+    const votes = document.createElement('span')
+    votes.className = 'bp-alt-votes'
+    votes.textContent = ` (${alternative.votes.toString()})`
+    score.appendChild(votes)
+  }
+
+  item.appendChild(name)
+  item.appendChild(score)
+  return item
 }
 
 function createSourceLink(

--- a/src/components/domUtils.ts
+++ b/src/components/domUtils.ts
@@ -280,7 +280,7 @@ export function setUncertain(productType: ProductType, rating: RatingResponse) {
   message.className = 'bp-message'
   message.innerText =
     alternatives.length > 0
-      ? `${i18n.t('didYouMean')}:`
+      ? `${i18n.t('closestMatches')}:`
       : i18n.t('uncertainMatch')
   ratingContainer.appendChild(message)
 

--- a/src/components/domUtils.ts
+++ b/src/components/domUtils.ts
@@ -130,6 +130,18 @@ const STYLES = `
     font-size: 11px;
     font-weight: 400;
   }
+  #${RATING_CONTAINER_ID} .bp-thumb {
+    width: 36px;
+    height: 48px;
+    object-fit: contain;
+    flex-shrink: 0;
+  }
+  #${RATING_CONTAINER_ID} .bp-alt-thumb {
+    width: 28px;
+    height: 38px;
+    object-fit: contain;
+    flex-shrink: 0;
+  }
   #${RATING_CONTAINER_ID} .bp-spinner-wrap {
     display: flex;
     justify-content: center;
@@ -247,6 +259,9 @@ export function setRating(
         ${svg}
         ${scoreHtml}
       `
+  if (rating.imageDataUrl) {
+    ratingRow.prepend(createThumbnail(rating.imageDataUrl, 'bp-thumb'))
+  }
 
   const meta = document.createElement('div')
   meta.className = 'bp-meta'
@@ -328,6 +343,10 @@ function createAlternativeItem(
   item.target = '_blank'
   item.rel = 'noopener noreferrer'
 
+  if (alternative.imageDataUrl) {
+    item.appendChild(createThumbnail(alternative.imageDataUrl, 'bp-alt-thumb'))
+  }
+
   const name = document.createElement('span')
   name.className = 'bp-alt-name'
   name.textContent = alternative.name
@@ -366,6 +385,14 @@ function createSourceLink(
     `<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7M9 7h8v8"/></svg>`
   )
   return linkElement
+}
+
+function createThumbnail(dataUrl: string, className: string): HTMLImageElement {
+  const img = document.createElement('img')
+  img.className = className
+  img.src = dataUrl
+  img.alt = ''
+  return img
 }
 
 function ensureStyles(): void {

--- a/src/components/ratingService.ts
+++ b/src/components/ratingService.ts
@@ -20,7 +20,10 @@ export async function fetchRating(
     const cachedRating = await tryGetRating(ratingRequest)
     // An entry cached by a list page has no thumbnails; when the product
     // page asks for images, refetch instead of serving the imageless copy.
-    if (cachedRating && !(includeImage && isMissingImages(cachedRating, type))) {
+    if (
+      cachedRating &&
+      !(includeImage && isMissingImages(cachedRating, type))
+    ) {
       return cachedRating
     }
     const response = await browser.runtime.sendMessage<
@@ -28,7 +31,10 @@ export async function fetchRating(
       RatingResponse
     >(ratingRequest)
 
-    if (response.status !== RatingResultStatus.NotFound && !response.transient) {
+    if (
+      response.status !== RatingResultStatus.NotFound &&
+      !response.transient
+    ) {
       await cacheRating(ratingRequest, response)
     }
     return response

--- a/src/components/ratingService.ts
+++ b/src/components/ratingService.ts
@@ -12,12 +12,15 @@ import { saveRating as cacheRating, tryGetRating } from './ratingsCache'
 export async function fetchRating(
   productId: string,
   productName: string,
-  type: ProductType
+  type: ProductType,
+  includeImage = false
 ): Promise<RatingResponse> {
   try {
-    const ratingRequest = { productId, productName, query: type }
+    const ratingRequest = { includeImage, productId, productName, query: type }
     const cachedRating = await tryGetRating(ratingRequest)
-    if (cachedRating) {
+    // An entry cached by a list page has no thumbnails; when the product
+    // page asks for images, refetch instead of serving the imageless copy.
+    if (cachedRating && !(includeImage && isMissingImages(cachedRating, type))) {
       return cachedRating
     }
     const response = await browser.runtime.sendMessage<
@@ -32,6 +35,16 @@ export async function fetchRating(
   } catch {
     return { status: RatingResultStatus.NotFound } as RatingResponse
   }
+}
+
+function isMissingImages(rating: RatingResponse, type: ProductType): boolean {
+  if (type !== ProductType.Wine) {
+    return false
+  }
+  if (rating.status === RatingResultStatus.Found) {
+    return !rating.imageDataUrl
+  }
+  return rating.alternatives?.some((a) => !a.imageDataUrl) ?? false
 }
 
 const LIST_FETCH_DELAY_MS = 300

--- a/src/components/ratingService.ts
+++ b/src/components/ratingService.ts
@@ -28,7 +28,7 @@ export async function fetchRating(
       RatingResponse
     >(ratingRequest)
 
-    if (response.status !== RatingResultStatus.NotFound) {
+    if (response.status !== RatingResultStatus.NotFound && !response.transient) {
       await cacheRating(ratingRequest, response)
     }
     return response

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -20,12 +20,12 @@ browser.runtime.onMessage.addListener(async (message: unknown) => {
   if (!isGetRatingMessage(message)) {
     return
   }
-  const { productName, query } = message
+  const { includeImage, productName, query } = message
   switch (query) {
     case ProductType.Beer:
     case ProductType.Cider:
       return await fetchRatingFromUntappd(productName)
     case ProductType.Wine:
-      return await fetchRatingFromVivino(productName)
+      return await fetchRatingFromVivino(productName, includeImage ?? true)
   }
 })

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -123,7 +123,7 @@ async function tryInsertOnProductPage() {
   try {
     domUtils.showLoadingSpinner()
 
-    const rating = await fetchRating(productId, productName, productType)
+    const rating = await fetchRating(productId, productName, productType, true)
     if (activeRequest !== request) return
     handleRating(productType, rating)
   } catch {

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -83,7 +83,7 @@ function handleRating(productType: ProductType, rating: RatingResponse) {
       domUtils.setRating(productType, rating, rating.link)
       return
     case RatingResultStatus.Uncertain:
-      domUtils.setUncertain(productType, rating.link)
+      domUtils.setUncertain(productType, rating)
       return
     default:
       domUtils.setMessage(i18n.t('noMatch'))

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1,4 +1,5 @@
 brewery: Brewery
+didYouMean: Did you mean
 linkToUntappd: Link to Untappd
 linkToVivino: Link to Vivino
 loading: Loading...

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1,5 +1,5 @@
 brewery: Brewery
-didYouMean: Did you mean
+closestMatches: Closest matches
 linkToUntappd: Link to Untappd
 linkToVivino: Link to Vivino
 loading: Loading...

--- a/src/locales/sv.yml
+++ b/src/locales/sv.yml
@@ -1,5 +1,5 @@
 brewery: Bryggeri
-didYouMean: Menade du
+closestMatches: Närmaste träffar
 linkToUntappd: Länk till Untappd
 linkToVivino: Länk till Vivino
 loading: Laddar...

--- a/src/locales/sv.yml
+++ b/src/locales/sv.yml
@@ -1,4 +1,5 @@
 brewery: Bryggeri
+didYouMean: Menade du
 linkToUntappd: Länk till Untappd
 linkToVivino: Länk till Vivino
 loading: Laddar...

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -36,12 +36,15 @@ export default defineConfig({
     host_permissions: [
       'https://www.systembolaget.se/*',
       'https://www.vivino.com/*',
+      // Vivino serves label/bottle thumbnails from separate image hosts
+      'https://images.vivino.com/*',
+      'https://thumbs.vivino.com/*',
       'https://untappd.com/*',
       // Untappd's Algolia search index, used for beer lookups
       'https://9wbo4rq3ho-dsn.algolia.net/*'
     ],
     content_security_policy: {
-      extension_pages: `script-src 'self'; object-src 'self'; connect-src 'self' https://www.vivino.com https://untappd.com https://9wbo4rq3ho-dsn.algolia.net${isProduction ? '' : ' ws://localhost:3000/'};`
+      extension_pages: `script-src 'self'; object-src 'self'; connect-src 'self' https://www.vivino.com https://images.vivino.com https://thumbs.vivino.com https://untappd.com https://9wbo4rq3ho-dsn.algolia.net${isProduction ? '' : ' ws://localhost:3000/'};`
     },
     browser_specific_settings: {
       gecko: {


### PR DESCRIPTION
## Why this PR exists
The stacked PRs #108 and #109 were merged, but **into each other's base branches, not into main** — #108 merged into `fix/vivino-vintage-link` and #109 into `feat/uncertain-alternatives`. Only #107 actually landed on main. This PR brings the already-reviewed feature work to main, plus a follow-up refinement commit.

## Contents
Already reviewed in #108/#109:
- "Närmaste träffar" alternatives picker on uncertain matches (top-3 ranked candidates, mobile-first tap targets)
- Vivino label thumbnails on the rating card and alternative rows (background-fetched as `data:` URLs to bypass the page CSP)

New refinements (post-review of the Sonnet implementation):
- **List pages no longer download thumbnails.** Badges never render images, yet every wine lookup fetched ~10–25 kB of label image and stored it as base64 in the cache. Requests now carry an `includeImage` flag; product pages opt in. A wine cached imageless by a list page is refetched when the product page wants images.
- **4s timeout on image downloads** so a hung request can't delay the rating card.
- **Internal fields (`similarityRate`, `imageUrl`) no longer leak** into message payloads and the cache.

## Test plan
- [x] `pnpm compile`, `pnpm lint`, `pnpm build:chrome`
- [x] Full Playwright suite: 18 passed (live-site e2e + mocked API tests, incl. new test that list-page requests perform zero image fetches and leak no internal fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)