### PR TITLE
fix: require a brand match before accepting a Vivino wine

### DIFF
--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -299,6 +299,102 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
     expect(result).not.toHaveProperty('imageUrl');
   });
 
+  // Regression: Vivino only indexes marketplace wines, so a wine that isn't on
+  // Vivino returns same-style, different-producer candidates. Shared style
+  // words ("Prosecco Extra Dry", "Blanc de Noirs Brut", "Cava Brut") push the
+  // name-similarity over 0.5, but with no brand token in common the result must
+  // be Uncertain, not a confidently-wrong Found. Reported cases:
+  //   Casteloro …  -> Alberto Nani Organic Prosecco Extra Dry
+  //   Noria …      -> Fleury Blanc de Noirs Brut Champagne
+  //   El Mar …     -> Mas Fi Cava Brut
+  for (const {
+    alt,
+    query,
+    winery,
+    wineName
+  } of [
+    {
+      alt: 'Alberto Nani Organic Prosecco Extra Dry',
+      query: 'Casteloro Prosecco Organic Extra Dry',
+      wineName: 'Alberto Nani Organic Prosecco Extra Dry',
+      winery: 'Alberto Nani'
+    },
+    {
+      alt: 'Fleury Blanc de Noirs Brut Champagne',
+      query: 'Noria Blanc de Noirs Brut',
+      wineName: 'Fleury Blanc de Noirs Brut Champagne',
+      winery: 'Fleury'
+    },
+    {
+      alt: 'Mas Fi Cava Brut',
+      query: 'El Mar Cava Brut',
+      wineName: 'Mas Fi Cava Brut',
+      winery: 'Mas Fi'
+    },
+    {
+      alt: 'Cuvage Brut Rosé',
+      query: 'Gorgeous Brut Rosé',
+      wineName: 'Cuvage Brut Rosé',
+      winery: 'Cuvage'
+    }
+  ]) {
+    test(`is Uncertain when only style words match, not the brand (${winery})`, async () => {
+      globalThis.fetch = (() =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              explore_vintage: {
+                matches: [
+                  {
+                    vintage: {
+                      id: 99,
+                      name: wineName,
+                      statistics: { ratings_average: 4.0, ratings_count: 500 },
+                      wine: { id: 100, seo_name: 'x', winery: { name: winery } }
+                    }
+                  }
+                ]
+              }
+            })
+        } as Response)) as typeof fetch;
+
+      const result = await fetchRatingFromVivino(query, false);
+
+      expect(result.status).toBe(RatingResultStatus.Uncertain);
+      expect(result.link).toContain('vivino.com/search/wines');
+      // The wrong wine is still offered as a "did you mean" suggestion.
+      expect(result.alternatives?.[0].name).toBe(alt);
+    });
+  }
+
+  test('stays Found when the brand token is shared', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            explore_vintage: {
+              matches: [
+                {
+                  vintage: {
+                    id: 55,
+                    name: 'Barefoot Bubbly Brut Cuvée',
+                    statistics: { ratings_average: 3.9, ratings_count: 900 },
+                    wine: { id: 56, seo_name: 'x', winery: { name: 'Barefoot' } }
+                  }
+                }
+              ]
+            }
+          })
+      } as Response)) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Barefoot Brut Cuvée', false);
+
+    expect(result.status).toBe(RatingResultStatus.Found);
+    expect(result.link).toBe('https://www.vivino.com/wines/55');
+  });
+
   test('returns no alternatives when the explore API has no matches', async () => {
     globalThis.fetch = (() =>
       Promise.resolve({

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -77,6 +77,7 @@ export interface VivinoMatch {
     wine: {
       id: number
       seo_name: string
+      winery?: null | { name: null | string }
     }
   }
 }

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -23,6 +23,51 @@ const MAX_ALTERNATIVES = 3
 // A hung image download must not hold up the rating itself.
 const IMAGE_FETCH_TIMEOUT_MS = 4000
 
+// Style/format words that are shared across thousands of unrelated wines. On
+// their own they must never be enough to accept a match: "Blanc de Noirs Brut"
+// or "Prosecco Extra Dry" can push the name-similarity over the accept
+// threshold even when the producer is completely different. The distinguishing
+// signal is the brand — enforced by the brand-overlap gate below.
+const GENERIC_WINE_WORDS = new Set([
+  'blanc',
+  'blancs',
+  'brut',
+  'cava',
+  'champagne',
+  'classico',
+  'cremant',
+  'crémant',
+  'demi',
+  'doc',
+  'docg',
+  'doux',
+  'dry',
+  'extra',
+  'gran',
+  'grande',
+  'noir',
+  'noirs',
+  'nv',
+  'organic',
+  'prosecco',
+  'reserva',
+  'reserve',
+  'riserva',
+  'rose',
+  'rosé',
+  'rouge',
+  'sec',
+  'sparkling',
+  'spumante',
+  'superiore',
+  'vintage',
+  'wine'
+])
+
+// How close two brand-like tokens must be to count as the same producer;
+// tolerates minor spelling/plural differences without matching unrelated words.
+const BRAND_TOKEN_MATCH_THRESHOLD = 0.8
+
 export async function fetchRatingFromUntappd(
   productName: string
 ): Promise<RatingResponse> {
@@ -153,11 +198,13 @@ export async function fetchRatingFromVivino(
     type ScoredWine = RatingResponse & {
       imageUrl?: string
       similarityRate: number
+      winery?: string
     }
 
     const scored = matches
       .map((match: VivinoMatch): ScoredWine => {
         const wineName = match.vintage.name
+        const winery = match.vintage.wine.winery?.name ?? undefined
         const rating = match.vintage.statistics.ratings_average ?? 0
         const votes = match.vintage.statistics.ratings_count ?? 0
         const link = `https://www.vivino.com/wines/${match.vintage.id.toString()}`
@@ -177,14 +224,23 @@ export async function fetchRatingFromVivino(
           rating,
           similarityRate,
           status: RatingResultStatus.Found,
-          votes
+          votes,
+          winery
         }
       })
       .sort((a, b) => b.similarityRate - a.similarityRate)
 
     const bestMatch = scored[0]
 
-    if (bestMatch.similarityRate < 0.5) {
+    // A high name-similarity built entirely on shared style words (e.g.
+    // "Prosecco Extra Dry") is not a real match unless the producer/brand also
+    // lines up; otherwise fall through to the Uncertain "did you mean" path.
+    const brandMatches = sharesBrandToken(
+      query,
+      `${bestMatch.winery ?? ''} ${bestMatch.name ?? ''}`
+    )
+
+    if (bestMatch.similarityRate < 0.5 || !brandMatches) {
       const top = scored.slice(0, MAX_ALTERNATIVES)
       if (includeImage) {
         await Promise.all(
@@ -210,6 +266,21 @@ export async function fetchRatingFromVivino(
   } catch {
     return { ...uncertainFallback, transient: true }
   }
+}
+
+// Splits text into lowercased, distinctive tokens: drops short filler ("de",
+// "di", "el"), bare vintage years, and the generic style words above, leaving
+// the brand/producer words that actually identify a wine.
+function distinctiveTokens(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^\p{L}\p{N}]+/u)
+    .filter(
+      (token) =>
+        token.length > 2 &&
+        !/^\d+$/.test(token) &&
+        !GENERIC_WINE_WORDS.has(token)
+    )
 }
 
 // Fetched by the background script because the systembolaget.se page CSP
@@ -245,6 +316,28 @@ function normalizeImageUrl(url: null | string | undefined): string | undefined {
     return undefined
   }
   return url.startsWith('//') ? `https:${url}` : url
+}
+
+// True when the query and candidate share a brand/producer token. Vivino's
+// explore results are all marketplace wines, so a same-style wine from a
+// different producer can outscore the (absent) real wine on style words alone;
+// requiring a brand token in common keeps those from being auto-accepted. When
+// the query has no distinctive token at all (name is entirely generic), there
+// is nothing to gate on, so it passes rather than block every candidate.
+function sharesBrandToken(query: string, candidate: string): boolean {
+  const queryTokens = distinctiveTokens(query)
+  if (queryTokens.length === 0) {
+    return true
+  }
+  const candidateTokens = distinctiveTokens(candidate)
+  return queryTokens.some((queryToken) =>
+    candidateTokens.some(
+      (candidateToken) =>
+        candidateToken === queryToken ||
+        stringSimilarity.compareTwoStrings(queryToken, candidateToken) >=
+          BRAND_TOKEN_MATCH_THRESHOLD
+    )
+  )
 }
 
 function toAlternatives(


### PR DESCRIPTION
## Problem

Several Systembolaget wines showed the rating of a **completely different wine**:

| Systembolaget | Wrongly shown as | Shared score / brand overlap |
|---|---|---|
| **Noria** Blanc de Noirs Brut (France) | Firriato / Fleury … Blanc de Noirs Brut | 0.60 / **0.0** |
| **Casteloro** Prosecco Organic Extra Dry (Italy) | **Alberto Nani** Organic Prosecco Extra Dry (Italy) | 0.63 / **0.0** |
| **El Mar** Cava Brut (Spain) | **Mas Fi** Cava Brut (Spain) | 0.67 / **0.0** |
| **Gorgeous** Brut Rosé (South Africa) | **Cuvage** Brut Rosé (Italy) | — / **0.0** |

Vivino's explore API only indexes marketplace wines. When a Systembolaget wine isn't on Vivino, the results are same-style wines from other producers. The similarity score compares the full query against `vintage.name` only, so shared generic style words ("Blanc de Noirs Brut", "Prosecco Extra Dry", "Cava Brut") clear the 0.5 accept threshold on their own — even though the one token that actually identifies the wine, the brand, has **zero** overlap. None of these four wines even exist on Vivino, so the correct outcome is *Uncertain*, not a confidently-wrong *Found*.

## Fix

The producer/brand is the decisive signal, and Vivino already returns it in the `winery` field (previously unread). After picking the best candidate, require that the query and the candidate (`winery` + `name`) share at least one **distinctive** (non-style) token; if not, fall through to the existing *Uncertain* "did you mean" path — search link + ranked alternatives — instead of asserting a wrong rating.

This is purely additive precision: it only converts some *Found* results into *Uncertain*, never the reverse, which matches the extension's existing "show a check-manually link rather than a wrong rating" philosophy.

### Why not country?

Considered and rejected as the primary fix. Three of the four mismatches above are **same-country** — a generic style like "Prosecco" or "Cava" basically implies its country, so country adds no discriminating power exactly where it's needed most. It would also require scraping Systembolaget's origin (shown in Swedish: *Spanien*, *Italia*) and mapping it to Vivino's English names — fragile surface for a secondary signal. Left as a possible follow-up filter.

## Testing

- Four mocked regression tests (one per reported mismatch shape) assert *Uncertain* + the wrong wine offered only as an alternative.
- A positive test confirms a shared brand token still resolves to *Found*.
- Verified end-to-end against the **live** Vivino API: all four reported names now return *Uncertain* with a proper search link, while the control wine (*Bread & Butter Chardonnay*) still returns *Found*.
- `pnpm compile`, `pnpm lint`, `pnpm ft:check`, and the full `api-integration.spec.ts` (18 tests) pass.
