### PR TITLE
fix: rebuild Vivino matching on its Algolia search index, gate on winery

### DIFF
--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -1,16 +1,29 @@
 import { test, expect } from '@playwright/test';
 import { fetchRatingFromVivino, fetchRatingFromUntappd } from '../src/components/api';
 import { RatingResultStatus } from '../src/@types/types';
+import type { VivinoHit } from '../src/@types/types';
 
 test.describe('API Integration Tests', () => {
   test('fetchRatingFromVivino returns data for valid query', async () => {
     const result = await fetchRatingFromVivino('Bread & Butter');
-    
+
     expect(result).not.toBeNull();
     expect(result?.status).toBe(RatingResultStatus.Found);
     expect(result?.rating).toBeGreaterThan(0);
     expect(result?.votes).toBeGreaterThan(0);
     expect(result?.link).toContain('vivino.com');
+  });
+
+  // Regression: the explore endpoint missed even top-selling wines (its index
+  // only covers marketplace listings). The Algolia index must find them.
+  test('fetchRatingFromVivino finds a top-selling wine', async () => {
+    const result = await fetchRatingFromVivino(
+      'Casillero del Diablo Cabernet Sauvignon',
+      false
+    );
+
+    expect(result.status).toBe(RatingResultStatus.Found);
+    expect(result.votes).toBeGreaterThan(10000);
   });
 
   test('fetchRatingFromUntappd returns data for valid query', async () => {
@@ -34,9 +47,26 @@ test.describe('API Integration Tests', () => {
   });
 });
 
-// Offline tests: the Vivino explore API only indexes marketplace wines, so a
-// miss must surface an Uncertain result with a working search link — never a
-// dead-end NotFound.
+// Builds an Algolia WINES_prod hit. Wine names in the index do NOT include
+// the producer — that lives in the separate winery field.
+function vivinoHit(overrides: Partial<VivinoHit> & { name: string }): VivinoHit {
+  return {
+    id: 1,
+    statistics: { ratings_average: 4.0, ratings_count: 100 },
+    vintages: [{ id: 9001, statistics: { ratings_count: 100 } }],
+    ...overrides
+  };
+}
+
+function vivinoSearchResponse(hits: VivinoHit[], nbHits?: number): Response {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ hits, nbHits: nbHits ?? hits.length })
+  } as Response;
+}
+
+// Offline tests: even Algolia misses some wines, so a miss must surface an
+// Uncertain result with a working search link — never a dead-end NotFound.
 test.describe('Vivino lookup misses (mocked fetch)', () => {
   const realFetch = globalThis.fetch;
 
@@ -44,12 +74,9 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
     globalThis.fetch = realFetch;
   });
 
-  test('returns Uncertain with a search link when the explore API has no matches', async () => {
+  test('returns Uncertain with a search link when the search has no hits', async () => {
     globalThis.fetch = (() =>
-      Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({ explore_vintage: { matches: [] } })
-      } as Response)) as typeof fetch;
+      Promise.resolve(vivinoSearchResponse([]))) as typeof fetch;
 
     const result = await fetchRatingFromVivino('Torre do Olivar');
 
@@ -86,66 +113,86 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
   // Regression test: vivino.com/wines/{id} resolves by vintage id, not the
   // generic wine id — using wine.id links to an unrelated wine (e.g. the
   // Black Stallion Cabernet Sauvignon 2023's wine.id 1166077 resolves to a
-  // 2005 Bourgogne Pinot Noir instead).
-  test('builds the wine link from the vintage id, not the generic wine id', async () => {
+  // 2005 Bourgogne Pinot Noir instead). The displayed rating is the pooled
+  // wine-level one, so the link must go to the most-rated vintage (Vivino's
+  // "all vintages" entry when present).
+  test('links the most-rated vintage, never the generic wine id', async () => {
     globalThis.fetch = (() =>
-      Promise.resolve({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            explore_vintage: {
-              matches: [
-                {
-                  vintage: {
-                    id: 173862896,
-                    name: 'Black Stallion Cabernet Sauvignon 2023',
-                    statistics: { ratings_average: 4.1, ratings_count: 54 },
-                    wine: {
-                      id: 1166077,
-                      seo_name: 'black-stallion-cabernet-sauvignon'
-                    }
-                  }
-                }
-              ]
-            }
+      Promise.resolve(
+        vivinoSearchResponse([
+          vivinoHit({
+            id: 1166077,
+            name: 'Cabernet Sauvignon',
+            vintages: [
+              { id: 173862896, statistics: { ratings_count: 54 } },
+              { id: 155001234, statistics: { ratings_count: 3 } }
+            ],
+            winery: { name: 'Black Stallion' }
           })
-      } as Response)) as typeof fetch;
+        ])
+      )) as typeof fetch;
 
     const result = await fetchRatingFromVivino(
-      'Black Stallion Napa Valley Cabernet Sauvignon 2023'
+      'Black Stallion Napa Valley Cabernet Sauvignon',
+      false
     );
 
+    expect(result.status).toBe(RatingResultStatus.Found);
     expect(result.link).toBe('https://www.vivino.com/wines/173862896');
   });
 
-  test('returns ranked alternatives when no Vivino match is confident enough', async () => {
-    const vivinoMatch = (id: number, name: string, rating: number, votes: number) => ({
-      vintage: {
-        id,
-        name,
-        statistics: { ratings_average: rating, ratings_count: votes },
-        wine: { id: id + 1, seo_name: 'irrelevant' }
-      }
-    });
-
+  test('falls back to the wine page when a hit has no vintages', async () => {
     globalThis.fetch = (() =>
-      Promise.resolve({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            explore_vintage: {
-              matches: [
-                // Similarities to the query (all below the 0.5 threshold):
-                // 0.200, 0.457, 0.167, 0.057 — so no auto-accept, and the
-                // ranked alternatives start with Falco Nero Riserva.
-                vivinoMatch(1, 'Torre Bianca Chardonnay', 4.0, 100),
-                vivinoMatch(2, 'Falco Nero Riserva', 4.4, 300),
-                vivinoMatch(3, 'Nero d Avola Sicilia', 3.8, 50),
-                vivinoMatch(4, 'Rioja Gran Reserva', 3.9, 80)
-              ]
-            }
+      Promise.resolve(
+        vivinoSearchResponse([
+          vivinoHit({
+            id: 8619,
+            name: 'Crianza',
+            vintages: [],
+            winery: { name: 'El Coto' }
           })
-      } as Response)) as typeof fetch;
+        ])
+      )) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('El Coto Crianza', false);
+
+    expect(result.status).toBe(RatingResultStatus.Found);
+    expect(result.link).toBe('https://www.vivino.com/w/8619');
+  });
+
+  test('returns ranked alternatives when no Vivino match is confident enough', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        vivinoSearchResponse([
+          // Fantasy wines with no winery data: none can be confirmed as the
+          // right producer, so even "Falco Nero Riserva" (similarity 0.514,
+          // above the 0.5 floor) must not auto-match — it leads the ranked
+          // alternatives instead.
+          vivinoHit({
+            id: 1,
+            name: 'Torre Bianca Chardonnay',
+            vintages: [{ id: 11, statistics: { ratings_count: 100 } }]
+          }),
+          vivinoHit({
+            id: 2,
+            name: 'Falco Nero Riserva',
+            statistics: { ratings_average: 4.4, ratings_count: 300 },
+            vintages: [{ id: 22, statistics: { ratings_count: 300 } }]
+          }),
+          vivinoHit({
+            id: 3,
+            name: 'Nero d Avola Sicilia',
+            statistics: { ratings_average: 3.8, ratings_count: 50 },
+            vintages: [{ id: 33, statistics: { ratings_count: 50 } }]
+          }),
+          vivinoHit({
+            id: 4,
+            name: 'Rioja Gran Reserva',
+            statistics: { ratings_average: 3.9, ratings_count: 80 },
+            vintages: [{ id: 44, statistics: { ratings_count: 80 } }]
+          })
+        ])
+      )) as typeof fetch;
 
     const result = await fetchRatingFromVivino('Torre del Falco Nero 2020');
 
@@ -154,7 +201,7 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
     // Capped at 3, ranked by similarity to the query.
     expect(result.alternatives).toHaveLength(3);
     expect(result.alternatives?.[0]).toEqual({
-      link: 'https://www.vivino.com/wines/2',
+      link: 'https://www.vivino.com/wines/22',
       name: 'Falco Nero Riserva',
       rating: 4.4,
       votes: 300
@@ -162,34 +209,25 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
   });
 
   test('attaches label thumbnails as data URLs (page CSP blocks hotlinking)', async () => {
-    const exploreJson = {
-      explore_vintage: {
-        matches: [
-          {
-            vintage: {
+    const fakePng = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('algolia.net')) {
+        return Promise.resolve(
+          vivinoSearchResponse([
+            vivinoHit({
               id: 42,
               image: {
                 variations: {
                   label_medium: '//images.vivino.com/thumbs/fake_150x200.png'
                 }
               },
-              name: 'Black Stallion Cabernet Sauvignon 2023',
-              statistics: { ratings_average: 4.1, ratings_count: 54 },
-              wine: { id: 43, seo_name: 'irrelevant' }
-            }
-          }
-        ]
-      }
-    };
-    const fakePng = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
-
-    globalThis.fetch = ((input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url.includes('/api/explore/explore')) {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(exploreJson)
-        } as Response);
+              name: 'Cabernet Sauvignon',
+              winery: { name: 'Black Stallion' }
+            })
+          ])
+        );
       }
       // Image request — must be the https-normalized thumbnail URL.
       expect(url).toBe('https://images.vivino.com/thumbs/fake_150x200.png');
@@ -201,7 +239,7 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
     }) as typeof fetch;
 
     const result = await fetchRatingFromVivino(
-      'Black Stallion Napa Valley Cabernet Sauvignon 2023'
+      'Black Stallion Napa Valley Cabernet Sauvignon'
     );
 
     expect(result.status).toBe(RatingResultStatus.Found);
@@ -214,30 +252,22 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
     const fakePng = new Uint8Array([1, 2, 3]);
     globalThis.fetch = ((input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.includes('/api/explore/explore')) {
-        return Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              explore_vintage: {
-                matches: [
-                  {
-                    vintage: {
-                      id: 7,
-                      image: {
-                        variations: {
-                          label_medium: '//images.vivino.com/thumbs/alt.png'
-                        }
-                      },
-                      name: 'Totally Unrelated Wine',
-                      statistics: { ratings_average: 4.0, ratings_count: 10 },
-                      wine: { id: 8, seo_name: 'x' }
-                    }
-                  }
-                ]
-              }
+      if (url.includes('algolia.net')) {
+        return Promise.resolve(
+          vivinoSearchResponse([
+            vivinoHit({
+              id: 7,
+              image: {
+                variations: {
+                  label_medium: '//images.vivino.com/thumbs/alt.png'
+                }
+              },
+              name: 'Totally Unrelated Wine',
+              vintages: [{ id: 77, statistics: { ratings_count: 10 } }],
+              winery: { name: 'Somebody Else' }
             })
-        } as Response);
+          ])
+        );
       }
       return Promise.resolve({
         arrayBuffer: () => Promise.resolve(fakePng.buffer),
@@ -257,37 +287,28 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
     const imageRequests: string[] = [];
     globalThis.fetch = ((input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.includes('/api/explore/explore')) {
-        return Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              explore_vintage: {
-                matches: [
-                  {
-                    vintage: {
-                      id: 42,
-                      image: {
-                        variations: {
-                          label_medium: '//images.vivino.com/thumbs/x.png'
-                        }
-                      },
-                      name: 'Black Stallion Cabernet Sauvignon 2023',
-                      statistics: { ratings_average: 4.1, ratings_count: 54 },
-                      wine: { id: 43, seo_name: 'irrelevant' }
-                    }
-                  }
-                ]
-              }
+      if (url.includes('algolia.net')) {
+        return Promise.resolve(
+          vivinoSearchResponse([
+            vivinoHit({
+              id: 42,
+              image: {
+                variations: {
+                  label_medium: '//images.vivino.com/thumbs/x.png'
+                }
+              },
+              name: 'Cabernet Sauvignon',
+              winery: { name: 'Black Stallion' }
             })
-        } as Response);
+          ])
+        );
       }
       imageRequests.push(url);
       return Promise.reject(new Error('unexpected image fetch'));
     }) as typeof fetch;
 
     const result = await fetchRatingFromVivino(
-      'Black Stallion Napa Valley Cabernet Sauvignon 2023',
+      'Black Stallion Napa Valley Cabernet Sauvignon',
       false
     );
 
@@ -296,14 +317,34 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
     expect(imageRequests).toHaveLength(0);
     // Internal scoring fields must not leak into the response/cache.
     expect(result).not.toHaveProperty('similarityRate');
+    expect(result).not.toHaveProperty('wineNameSimilarityRate');
     expect(result).not.toHaveProperty('imageUrl');
+    expect(result).not.toHaveProperty('winery');
   });
 
-  // Regression: Vivino only indexes marketplace wines, so a wine that isn't on
-  // Vivino returns same-style, different-producer candidates. Shared style
-  // words ("Prosecco Extra Dry", "Blanc de Noirs Brut", "Cava Brut") push the
-  // name-similarity over 0.5, but with no brand token in common the result must
-  // be Uncertain, not a confidently-wrong Found. Reported cases:
+  test('ignores hidden hits', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        vivinoSearchResponse([
+          vivinoHit({
+            hidden: true,
+            name: 'Brut Cuvée',
+            winery: { name: 'Barefoot' }
+          })
+        ])
+      )) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Barefoot Brut Cuvée', false);
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.alternatives).toBeUndefined();
+  });
+
+  // Regression: a wine that isn't on Vivino returns same-style,
+  // different-producer candidates. Shared style words ("Prosecco Extra Dry",
+  // "Blanc de Noirs Brut", "Cava Brut") push the name-similarity over 0.5,
+  // but with an unconfirmed winery the result must be Uncertain, not a
+  // confidently-wrong Found. Reported cases:
   //   Casteloro …  -> Alberto Nani Organic Prosecco Extra Dry
   //   Noria …      -> Fleury Blanc de Noirs Brut Champagne
   //   El Mar …     -> Mas Fi Cava Brut
@@ -316,91 +357,262 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
     {
       alt: 'Alberto Nani Organic Prosecco Extra Dry',
       query: 'Casteloro Prosecco Organic Extra Dry',
-      wineName: 'Alberto Nani Organic Prosecco Extra Dry',
+      wineName: 'Organic Prosecco Extra Dry',
       winery: 'Alberto Nani'
     },
     {
       alt: 'Fleury Blanc de Noirs Brut Champagne',
       query: 'Noria Blanc de Noirs Brut',
-      wineName: 'Fleury Blanc de Noirs Brut Champagne',
+      wineName: 'Blanc de Noirs Brut Champagne',
       winery: 'Fleury'
     },
     {
       alt: 'Mas Fi Cava Brut',
       query: 'El Mar Cava Brut',
-      wineName: 'Mas Fi Cava Brut',
+      wineName: 'Cava Brut',
       winery: 'Mas Fi'
     },
     {
       alt: 'Cuvage Brut Rosé',
       query: 'Gorgeous Brut Rosé',
-      wineName: 'Cuvage Brut Rosé',
+      wineName: 'Brut Rosé',
       winery: 'Cuvage'
     }
   ]) {
-    test(`is Uncertain when only style words match, not the brand (${winery})`, async () => {
+    test(`is Uncertain when only style words match, not the producer (${winery})`, async () => {
       globalThis.fetch = (() =>
-        Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              explore_vintage: {
-                matches: [
-                  {
-                    vintage: {
-                      id: 99,
-                      name: wineName,
-                      statistics: { ratings_average: 4.0, ratings_count: 500 },
-                      wine: { id: 100, seo_name: 'x', winery: { name: winery } }
-                    }
-                  }
-                ]
-              }
+        Promise.resolve(
+          vivinoSearchResponse([
+            vivinoHit({
+              id: 99,
+              name: wineName,
+              statistics: { ratings_average: 4.0, ratings_count: 500 },
+              vintages: [{ id: 990, statistics: { ratings_count: 500 } }],
+              winery: { name: winery }
             })
-        } as Response)) as typeof fetch;
+          ])
+        )) as typeof fetch;
 
       const result = await fetchRatingFromVivino(query, false);
 
       expect(result.status).toBe(RatingResultStatus.Uncertain);
       expect(result.link).toContain('vivino.com/search/wines');
-      // The wrong wine is still offered as a "did you mean" suggestion.
+      // The wrong wine is still offered as a "did you mean" suggestion,
+      // displayed with its producer.
       expect(result.alternatives?.[0].name).toBe(alt);
     });
   }
 
-  test('stays Found when the brand token is shared', async () => {
+  test('stays Found when the winery is confirmed by the query', async () => {
     globalThis.fetch = (() =>
-      Promise.resolve({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            explore_vintage: {
-              matches: [
-                {
-                  vintage: {
-                    id: 55,
-                    name: 'Barefoot Bubbly Brut Cuvée',
-                    statistics: { ratings_average: 3.9, ratings_count: 900 },
-                    wine: { id: 56, seo_name: 'x', winery: { name: 'Barefoot' } }
-                  }
-                }
-              ]
-            }
+      Promise.resolve(
+        vivinoSearchResponse([
+          vivinoHit({
+            id: 55,
+            name: 'Bubbly Brut Cuvée',
+            statistics: { ratings_average: 3.9, ratings_count: 900 },
+            vintages: [{ id: 550, statistics: { ratings_count: 900 } }],
+            winery: { name: 'Barefoot' }
           })
-      } as Response)) as typeof fetch;
+        ])
+      )) as typeof fetch;
 
     const result = await fetchRatingFromVivino('Barefoot Brut Cuvée', false);
 
     expect(result.status).toBe(RatingResultStatus.Found);
-    expect(result.link).toBe('https://www.vivino.com/wines/55');
+    expect(result.link).toBe('https://www.vivino.com/wines/550');
   });
 
-  test('returns no alternatives when the explore API has no matches', async () => {
+  // Regression: an any-token winery check would accept "Knight Black Horse"
+  // for "Black Knight" (two shared tokens, different producer). Every
+  // distinctive winery token must appear in the query.
+  test('rejects a winery that only partially overlaps the query', async () => {
     globalThis.fetch = (() =>
-      Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({ explore_vintage: { matches: [] } })
-      } as Response)) as typeof fetch;
+      Promise.resolve(
+        vivinoSearchResponse([
+          vivinoHit({
+            name: 'Black Opal Cabernet Sauvignon',
+            winery: { name: 'Knight Black Horse' }
+          })
+        ])
+      )) as typeof fetch;
+
+    const result = await fetchRatingFromVivino(
+      'Black Knight Cabernet Sauvignon',
+      false
+    );
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+  });
+
+  // A hit with no winery data can still be accepted when the name alone is
+  // exactly the query — but only exactly. A similarity threshold is not
+  // enough: compareTwoStrings ignores whitespace, so "Riesling Organic"
+  // scores 0.97 against "R Riesling Organic" yet is a different producer's
+  // wine.
+  test('accepts a winery-less hit only on an exact name', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        vivinoSearchResponse([
+          vivinoHit({ name: 'Black Knight Cabernet Sauvignon' })
+        ])
+      )) as typeof fetch;
+
+    const exact = await fetchRatingFromVivino(
+      'Black Knight Cabernet Sauvignon',
+      false
+    );
+    expect(exact.status).toBe(RatingResultStatus.Found);
+
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        vivinoSearchResponse([vivinoHit({ name: 'Riesling Organic' })])
+      )) as typeof fetch;
+
+    const close = await fetchRatingFromVivino('R Riesling Organic', false);
+    expect(close.status).toBe(RatingResultStatus.Uncertain);
+  });
+
+  // Regression: the confirmed producer must win even when a same-style wine
+  // from another producer has the higher name-similarity. Gating only the
+  // top-ranked candidate turned "Mionetto Prosecco Brut" into an Uncertain
+  // because Masottina's prosecco outscored Mionetto's own.
+  test('prefers a confirmed producer over a better-scoring namesake style', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        vivinoSearchResponse([
+          vivinoHit({
+            id: 1,
+            name: 'Prosecco Brut',
+            vintages: [{ id: 111, statistics: { ratings_count: 4000 } }],
+            winery: { name: 'Masottina' }
+          }),
+          vivinoHit({
+            id: 2,
+            name: 'Prestige Collection Brut Prosecco Treviso',
+            statistics: { ratings_average: 3.8, ratings_count: 31142 },
+            vintages: [{ id: 222, statistics: { ratings_count: 31142 } }],
+            winery: { name: 'Mionetto' }
+          })
+        ])
+      )) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Mionetto Prosecco Brut', false);
+
+    expect(result.status).toBe(RatingResultStatus.Found);
+    expect(result.name).toBe(
+      'Mionetto Prestige Collection Brut Prosecco Treviso'
+    );
+    expect(result.link).toBe('https://www.vivino.com/wines/222');
+  });
+
+  // Regression: "Château"/"Bodegas"/"Weingut" are corporate-form words, not
+  // brands. They are skipped when confirming the winery, so the remaining
+  // token ("Pajzos") decides — and it is not in this query.
+  test('does not confirm a winery on a shared corporate-form word', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        vivinoSearchResponse([
+          vivinoHit({
+            name: 'Aszú 5 Puttonyos',
+            statistics: { ratings_average: 4.3, ratings_count: 168 },
+            winery: { name: 'Château Pajzos' }
+          })
+        ])
+      )) as typeof fetch;
+
+    const result = await fetchRatingFromVivino(
+      'Château Dereszla Tokaji Aszù 5 Puttonyos',
+      false
+    );
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+  });
+
+  // Products whose Systembolaget title omits the producer ("Barbera d'Alba
+  // Busije" is by Giacosa Fratelli) can only match on the name itself. An
+  // exact name on a distinctive title (few index-wide hits) is accepted, and
+  // the comparison must tolerate Vivino's typographic apostrophes.
+  test('accepts an exact distinctive name even when the producer is not in the title', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        vivinoSearchResponse(
+          [
+            vivinoHit({
+              name: 'Barbera d’Alba Busije',
+              statistics: { ratings_average: 3.9, ratings_count: 16073 },
+              winery: { name: 'Giacosa Fratelli' }
+            })
+          ],
+          2
+        )
+      )) as typeof fetch;
+
+    const result = await fetchRatingFromVivino("Barbera d'Alba Busije", false);
+
+    expect(result.status).toBe(RatingResultStatus.Found);
+    expect(result.name).toBe('Giacosa Fratelli Barbera d’Alba Busije');
+  });
+
+  // Regression: an exact name on a GENERIC title is no proof of identity —
+  // "Piemonte Barbera" exists verbatim under several producers (1714 index
+  // hits), and Systembolaget's is not the one Vivino ranks first. Stays
+  // Uncertain, with the namesake as a suggestion.
+  test('stays Uncertain on an exact name that is common in the index', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        vivinoSearchResponse(
+          [
+            vivinoHit({
+              name: 'Piemonte Barbera',
+              winery: { name: 'Marco Pontarelli' }
+            })
+          ],
+          1714
+        )
+      )) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('Piemonte Barbera', false);
+
+    expect(result.status).toBe(RatingResultStatus.Uncertain);
+    expect(result.alternatives?.[0].name).toBe(
+      'Marco Pontarelli Piemonte Barbera'
+    );
+  });
+
+  // Same producer, several cuvées: the wine whose name actually matches must
+  // win, not whichever the search ranks first.
+  test('picks the matching cuvée among same-producer hits', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        vivinoSearchResponse([
+          vivinoHit({
+            id: 1181471,
+            name: 'Coto Mayor Crianza',
+            statistics: { ratings_average: 3.7, ratings_count: 9940 },
+            vintages: [{ id: 111, statistics: { ratings_count: 9940 } }],
+            winery: { name: 'El Coto' }
+          }),
+          vivinoHit({
+            id: 8619,
+            name: 'Crianza',
+            statistics: { ratings_average: 3.6, ratings_count: 76089 },
+            vintages: [{ id: 222, statistics: { ratings_count: 76089 } }],
+            winery: { name: 'El Coto' }
+          })
+        ])
+      )) as typeof fetch;
+
+    const result = await fetchRatingFromVivino('El Coto Crianza', false);
+
+    expect(result.status).toBe(RatingResultStatus.Found);
+    expect(result.name).toBe('El Coto Crianza');
+    expect(result.link).toBe('https://www.vivino.com/wines/222');
+  });
+
+  test('returns no alternatives when the search has no hits', async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(vivinoSearchResponse([]))) as typeof fetch;
 
     const result = await fetchRatingFromVivino('Torre do Olivar');
 

--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -65,6 +65,12 @@ function vivinoSearchResponse(hits: VivinoHit[], nbHits?: number): Response {
   } as Response;
 }
 
+// Routes mocked fetches: true for the Algolia search call, false for the
+// image downloads that follow it.
+function isVivinoSearchUrl(url: string): boolean {
+  return new URL(url).hostname === '9takgwjuxl-dsn.algolia.net';
+}
+
 // Offline tests: even Algolia misses some wines, so a miss must surface an
 // Uncertain result with a working search link — never a dead-end NotFound.
 test.describe('Vivino lookup misses (mocked fetch)', () => {
@@ -213,7 +219,7 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
 
     globalThis.fetch = ((input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.includes('algolia.net')) {
+      if (isVivinoSearchUrl(url)) {
         return Promise.resolve(
           vivinoSearchResponse([
             vivinoHit({
@@ -252,7 +258,7 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
     const fakePng = new Uint8Array([1, 2, 3]);
     globalThis.fetch = ((input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.includes('algolia.net')) {
+      if (isVivinoSearchUrl(url)) {
         return Promise.resolve(
           vivinoSearchResponse([
             vivinoHit({
@@ -287,7 +293,7 @@ test.describe('Vivino lookup misses (mocked fetch)', () => {
     const imageRequests: string[] = [];
     globalThis.fetch = ((input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.includes('algolia.net')) {
+      if (isVivinoSearchUrl(url)) {
         return Promise.resolve(
           vivinoSearchResponse([
             vivinoHit({

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -60,28 +60,28 @@ export interface UntappdSearchJSON {
   hits?: UntappdHit[]
 }
 
-export interface VivinoMatch {
-  vintage: {
-    id: number
-    image?: {
-      location?: null | string
-      variations?: {
-        label_medium?: string
-      }
-    }
-    name: string
-    statistics: {
-      ratings_average: null | number
-      ratings_count: null | number
-    }
-    wine: {
-      id: number
-      seo_name: string
-      winery?: null | { name: null | string }
+export interface VivinoHit {
+  hidden?: boolean
+  id: number
+  image?: {
+    location?: null | string
+    variations?: {
+      label_medium?: string
     }
   }
+  name: string
+  statistics?: {
+    ratings_average: null | number
+    ratings_count: null | number
+  }
+  vintages?: {
+    id: number
+    statistics?: { ratings_count: null | number }
+  }[]
+  winery?: null | { name: null | string }
 }
 
-export interface VivinoResponseJSON {
-  explore_vintage?: { matches: VivinoMatch[] }
+export interface VivinoSearchJSON {
+  hits?: VivinoHit[]
+  nbHits?: number
 }

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -318,25 +318,25 @@ function normalizeImageUrl(url: null | string | undefined): string | undefined {
   return url.startsWith('//') ? `https:${url}` : url
 }
 
-// True when the query and candidate share a brand/producer token. Vivino's
-// explore results are all marketplace wines, so a same-style wine from a
-// different producer can outscore the (absent) real wine on style words alone;
-// requiring a brand token in common keeps those from being auto-accepted. When
-// the query has no distinctive token at all (name is entirely generic), there
-// is nothing to gate on, so it passes rather than block every candidate.
+// True when the candidate contains the query's brand token. Systembolaget puts
+// the producer/brand first in the product title, so the query's leading
+// distinctive token is the brand. Requiring that specific token — not just any
+// overlap — keeps shared appellation names (Conegliano, Valdobbiadene, Rioja,
+// …) from passing the gate for a different producer's wine: those are as
+// generic as the style words but far too numerous to blocklist. When the query
+// has no distinctive token at all (name is entirely generic), there is nothing
+// to gate on, so it passes rather than block every candidate.
 function sharesBrandToken(query: string, candidate: string): boolean {
   const queryTokens = distinctiveTokens(query)
   if (queryTokens.length === 0) {
     return true
   }
-  const candidateTokens = distinctiveTokens(candidate)
-  return queryTokens.some((queryToken) =>
-    candidateTokens.some(
-      (candidateToken) =>
-        candidateToken === queryToken ||
-        stringSimilarity.compareTwoStrings(queryToken, candidateToken) >=
-          BRAND_TOKEN_MATCH_THRESHOLD
-    )
+  const brandToken = queryTokens[0]
+  return distinctiveTokens(candidate).some(
+    (candidateToken) =>
+      candidateToken === brandToken ||
+      stringSimilarity.compareTwoStrings(brandToken, candidateToken) >=
+        BRAND_TOKEN_MATCH_THRESHOLD
   )
 }
 

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -7,14 +7,23 @@ import {
   RatingResultStatus,
   UntappdHit,
   UntappdSearchJSON,
-  VivinoMatch,
-  VivinoResponseJSON
+  VivinoHit,
+  VivinoSearchJSON
 } from '@/@types/types'
 
 // Untappd's search page renders results client-side via Algolia; these are the
 // public search-only credentials it ships to anonymous visitors.
 const UNTAPPD_ALGOLIA_APP_ID = '9WBO4RQ3HO'
 const UNTAPPD_ALGOLIA_SEARCH_KEY = '1d347324d67ec472bb7132c66aead485'
+
+// Vivino's search box is also Algolia-backed with public search-only
+// credentials shipped to anonymous visitors. The WINES_prod index has far
+// better text relevance than the /api/explore/explore endpoint (a marketplace
+// browser that misses even top-selling wines and non-marketplace producers),
+// and each hit carries the winery as a separate field, so the producer check
+// no longer has to guess which query token is the brand.
+const VIVINO_ALGOLIA_APP_ID = '9TAKGWJUXL'
+const VIVINO_ALGOLIA_SEARCH_KEY = '60c11b2f1068885161d95ca068d3a6ae'
 
 // How many ranked candidates to surface as "did you mean" alternatives when
 // no match is confident enough to auto-select.
@@ -27,7 +36,7 @@ const IMAGE_FETCH_TIMEOUT_MS = 4000
 // their own they must never be enough to accept a match: "Blanc de Noirs Brut"
 // or "Prosecco Extra Dry" can push the name-similarity over the accept
 // threshold even when the producer is completely different. The distinguishing
-// signal is the brand — enforced by the brand-overlap gate below.
+// signal is the producer — enforced by the winery check below.
 const GENERIC_WINE_WORDS = new Set([
   'blanc',
   'blancs',
@@ -67,6 +76,63 @@ const GENERIC_WINE_WORDS = new Set([
 // How close two brand-like tokens must be to count as the same producer;
 // tolerates minor spelling/plural differences without matching unrelated words.
 const BRAND_TOKEN_MATCH_THRESHOLD = 0.8
+
+// An exact name only identifies a wine when that name is rare in the index.
+// Distinctive titles ("Contacto Loureiro", "Barbera d'Alba Busije") match a
+// handful of wines; appellation-and-grape titles ("Piemonte Barbera") match
+// hundreds under many producers, so an exact hit proves nothing there.
+// Audited values: correct exact matches sat at 1–12 total hits, wrong ones at
+// 49 and 1714.
+const MAX_HITS_FOR_EXACT_NAME_MATCH = 20
+
+// Corporate-form words in winery names ("Weingut X", "Bodegas Y", "X Family
+// Estate") that Systembolaget titles routinely drop. They are excluded from
+// the winery check so "Saint Clair Family Estate" is confirmed by a title
+// that only says "Saint Clair" — but every remaining winery token must appear
+// in the query: any-token overlap would let "Knight Black Horse" pass for
+// "Black Knight".
+const WINERY_COMPANY_WORDS = new Set([
+  'agricola',
+  'azienda',
+  'bodega',
+  'bodegas',
+  'cantina',
+  'cantine',
+  'casa',
+  'cave',
+  'caves',
+  'cellars',
+  'chateau',
+  'château',
+  'domaine',
+  'domaines',
+  'estate',
+  'estates',
+  'famiglia',
+  'familia',
+  'familie',
+  'famille',
+  'family',
+  'fratelli',
+  'frères',
+  'hermanos',
+  'maison',
+  'tenuta',
+  'tenute',
+  'vigne',
+  'vigneron',
+  'vignerons',
+  'vignobles',
+  'vina',
+  'viña',
+  'vineyard',
+  'vineyards',
+  'vinos',
+  'vinya',
+  'weingut',
+  'winery',
+  'winzer'
+])
 
 export async function fetchRatingFromUntappd(
   productName: string
@@ -154,19 +220,10 @@ export async function fetchRatingFromVivino(
   query: string,
   includeImage = true
 ): Promise<RatingResponse> {
-  const params = new URLSearchParams({
-    facets: 'false',
-    language: 'en',
-    min_rating: '0',
-    order: 'desc',
-    order_by: 'relevance',
-    page: '1',
-    search_term: query
-  })
-  const url = `https://www.vivino.com/api/explore/explore?${params.toString()}`
-  // Vivino's explore API only indexes marketplace wines, so misses are common
-  // (catalogue-only wines, regional gaps). Instead of a dead-end "no rating"
-  // message, always hand the user a working Vivino search link.
+  const url = `https://${VIVINO_ALGOLIA_APP_ID.toLowerCase()}-dsn.algolia.net/1/indexes/WINES_prod/query`
+  // Even Algolia misses some wines (obscure producers, new releases). Instead
+  // of a dead-end "no rating" message, always hand the user a working Vivino
+  // search link.
   const uncertainFallback = {
     link: `https://www.vivino.com/search/wines?q=${encodeURIComponent(query)}`,
     status: RatingResultStatus.Uncertain
@@ -174,12 +231,18 @@ export async function fetchRatingFromVivino(
 
   try {
     const response = await fetch(url, {
-      credentials: 'include',
+      body: JSON.stringify({
+        params: new URLSearchParams({
+          hitsPerPage: '10',
+          query
+        }).toString()
+      }),
       headers: {
-        Accept: 'application/json',
-        'User-Agent':
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36'
-      }
+        'Content-Type': 'application/json',
+        'X-Algolia-API-Key': VIVINO_ALGOLIA_SEARCH_KEY,
+        'X-Algolia-Application-Id': VIVINO_ALGOLIA_APP_ID
+      },
+      method: 'POST'
     })
 
     // HTTP errors (429 rate limit, 5xx) are transient — show the search-link
@@ -188,41 +251,45 @@ export async function fetchRatingFromVivino(
       return { ...uncertainFallback, transient: true }
     }
 
-    const data = (await response.json()) as VivinoResponseJSON
-    const matches = data.explore_vintage?.matches ?? []
+    const data = (await response.json()) as VivinoSearchJSON
+    const hits = (data.hits ?? []).filter((hit) => !hit.hidden)
 
-    if (matches.length === 0) {
+    if (hits.length === 0) {
       return uncertainFallback
     }
 
     type ScoredWine = RatingResponse & {
+      exactNameMatch: boolean
       imageUrl?: string
       similarityRate: number
       winery?: string
     }
 
-    const scored = matches
-      .map((match: VivinoMatch): ScoredWine => {
-        const wineName = match.vintage.name
-        const winery = match.vintage.wine.winery?.name ?? undefined
-        const rating = match.vintage.statistics.ratings_average ?? 0
-        const votes = match.vintage.statistics.ratings_count ?? 0
-        const link = `https://www.vivino.com/wines/${match.vintage.id.toString()}`
+    const scored = hits
+      .map((hit: VivinoHit): ScoredWine => {
+        const winery = hit.winery?.name ?? undefined
+        // Hits name the wine without the producer ("Crianza" under winery
+        // "El Coto"), so score against the combined name — unless the wine
+        // name already repeats the winery.
+        const fullName =
+          winery && !normalize(hit.name).startsWith(normalize(winery))
+            ? `${winery} ${hit.name}`
+            : hit.name
+        const rating = hit.statistics?.ratings_average ?? 0
+        const votes = hit.statistics?.ratings_count ?? 0
         const imageUrl = normalizeImageUrl(
-          match.vintage.image?.variations?.label_medium ??
-            match.vintage.image?.location
-        )
-        const similarityRate = stringSimilarity.compareTwoStrings(
-          query,
-          wineName
+          hit.image?.variations?.label_medium ?? hit.image?.location
         )
 
         return {
+          exactNameMatch:
+            normalize(hit.name) === normalize(query) ||
+            normalize(fullName) === normalize(query),
           imageUrl,
-          link,
-          name: wineName,
+          link: wineLink(hit),
+          name: fullName,
           rating,
-          similarityRate,
+          similarityRate: similarity(query, fullName),
           status: RatingResultStatus.Found,
           votes,
           winery
@@ -230,17 +297,26 @@ export async function fetchRatingFromVivino(
       })
       .sort((a, b) => b.similarityRate - a.similarityRate)
 
-    const bestMatch = scored[0]
-
-    // A high name-similarity built entirely on shared style words (e.g.
-    // "Prosecco Extra Dry") is not a real match unless the producer/brand also
-    // lines up; otherwise fall through to the Uncertain "did you mean" path.
-    const brandMatches = sharesBrandToken(
-      query,
-      `${bestMatch.winery ?? ''} ${bestMatch.name ?? ''}`
+    // A name-similarity built on shared style words ("Prosecco Extra Dry") is
+    // not a real match unless the producer also lines up: the winery must be
+    // confirmed by the query. Checked down the ranking, not only on the top
+    // candidate — a confirmed producer at rank 3 beats an unconfirmable
+    // near-namesake at rank 1. The one exception is an exact-name hit on a
+    // distinctive title (few wines in the whole index share the name), which
+    // covers products whose Systembolaget title omits the producer. Exact
+    // means exact: a similarity threshold cannot replace it, because
+    // compareTwoStrings ignores whitespace and scores "Riesling Organic" 0.97
+    // against "R Riesling Organic", a different producer's wine.
+    const nameIsDistinctive =
+      (data.nbHits ?? Infinity) <= MAX_HITS_FOR_EXACT_NAME_MATCH
+    const bestMatch = scored.find(
+      (wine) =>
+        wine.similarityRate >= 0.5 &&
+        (queryContainsWinery(query, wine.winery) ||
+          (wine.exactNameMatch && nameIsDistinctive))
     )
 
-    if (bestMatch.similarityRate < 0.5 || !brandMatches) {
+    if (!bestMatch) {
       const top = scored.slice(0, MAX_ALTERNATIVES)
       if (includeImage) {
         await Promise.all(
@@ -311,6 +387,20 @@ async function fetchImageAsDataUrl(
   }
 }
 
+// Lowercases and folds diacritics and punctuation so cosmetic spelling
+// differences between the two catalogues don't break comparisons: Vivino
+// writes "Barbera d’Alba" and "Bobal - Syrah" where Systembolaget writes
+// "Barbera d'Alba" and "Bobal Syrah", and accents drift both ways
+// ("Aszù"/"Aszú").
+function normalize(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{M}+/gu, '')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+}
+
 function normalizeImageUrl(url: null | string | undefined): string | undefined {
   if (!url) {
     return undefined
@@ -318,26 +408,38 @@ function normalizeImageUrl(url: null | string | undefined): string | undefined {
   return url.startsWith('//') ? `https:${url}` : url
 }
 
-// True when the candidate contains the query's brand token. Systembolaget puts
-// the producer/brand first in the product title, so the query's leading
-// distinctive token is the brand. Requiring that specific token — not just any
-// overlap — keeps shared appellation names (Conegliano, Valdobbiadene, Rioja,
-// …) from passing the gate for a different producer's wine: those are as
-// generic as the style words but far too numerous to blocklist. When the query
-// has no distinctive token at all (name is entirely generic), there is nothing
-// to gate on, so it passes rather than block every candidate.
-function sharesBrandToken(query: string, candidate: string): boolean {
-  const queryTokens = distinctiveTokens(query)
-  if (queryTokens.length === 0) {
-    return true
+// True when every distinctive token of the winery name appears in the query
+// (fuzzily, to tolerate spelling drift). Corporate-form words are skipped —
+// Systembolaget writes "Saint Clair", Vivino "Saint Clair Family Estate" —
+// but the remaining tokens must ALL be present: any-token overlap would let
+// "Knight Black Horse" pass for "Black Knight". An unknown winery cannot be
+// confirmed and never passes.
+function queryContainsWinery(
+  query: string,
+  winery: string | undefined
+): boolean {
+  if (!winery) {
+    return false
   }
-  const brandToken = queryTokens[0]
-  return distinctiveTokens(candidate).some(
-    (candidateToken) =>
-      candidateToken === brandToken ||
-      stringSimilarity.compareTwoStrings(brandToken, candidateToken) >=
-        BRAND_TOKEN_MATCH_THRESHOLD
+  const wineryTokens = distinctiveTokens(winery).filter(
+    (token) => !WINERY_COMPANY_WORDS.has(token)
   )
+  if (wineryTokens.length === 0) {
+    return false
+  }
+  const queryTokens = distinctiveTokens(query)
+  return wineryTokens.every((wineryToken) =>
+    queryTokens.some(
+      (queryToken) =>
+        queryToken === wineryToken ||
+        stringSimilarity.compareTwoStrings(wineryToken, queryToken) >=
+          BRAND_TOKEN_MATCH_THRESHOLD
+    )
+  )
+}
+
+function similarity(a: string, b: string): number {
+  return stringSimilarity.compareTwoStrings(normalize(a), normalize(b))
 }
 
 function toAlternatives(
@@ -356,4 +458,25 @@ function toAlternatives(
         ? [{ imageDataUrl, link, name, rating, votes }]
         : []
     )
+}
+
+// vivino.com/wines/{id} resolves by vintage id, not wine id (see the
+// regression note in the tests). The displayed rating is the wine-level
+// pooled one, so link the most-rated vintage — the "all vintages" entry when
+// Vivino has one. Wines without vintage data fall back to the /w/{wine id}
+// page.
+function wineLink(hit: VivinoHit): string {
+  const bestVintage = (hit.vintages ?? []).reduce<
+    NonNullable<VivinoHit['vintages']>[number] | null
+  >(
+    (best, vintage) =>
+      (vintage.statistics?.ratings_count ?? 0) >
+      (best?.statistics?.ratings_count ?? -1)
+        ? vintage
+        : best,
+    null
+  )
+  return bestVintage
+    ? `https://www.vivino.com/wines/${bestVintage.id.toString()}`
+    : `https://www.vivino.com/w/${hit.id.toString()}`
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -41,10 +41,12 @@ export default defineConfig({
       'https://thumbs.vivino.com/*',
       'https://untappd.com/*',
       // Untappd's Algolia search index, used for beer lookups
-      'https://9wbo4rq3ho-dsn.algolia.net/*'
+      'https://9wbo4rq3ho-dsn.algolia.net/*',
+      // Vivino's Algolia search index, used for wine lookups
+      'https://9takgwjuxl-dsn.algolia.net/*'
     ],
     content_security_policy: {
-      extension_pages: `script-src 'self'; object-src 'self'; connect-src 'self' https://www.vivino.com https://images.vivino.com https://thumbs.vivino.com https://untappd.com https://9wbo4rq3ho-dsn.algolia.net${isProduction ? '' : ' ws://localhost:3000/'};`
+      extension_pages: `script-src 'self'; object-src 'self'; connect-src 'self' https://www.vivino.com https://images.vivino.com https://thumbs.vivino.com https://untappd.com https://9wbo4rq3ho-dsn.algolia.net https://9takgwjuxl-dsn.algolia.net${isProduction ? '' : ' ws://localhost:3000/'};`
     },
     browser_specific_settings: {
       gecko: {


### PR DESCRIPTION
Follow-up investigation of the wrong-match reports (first seen under mousserande, but present in every category). A 90-wine audit against the live Systembolaget catalogue — 30 each sparkling/red/white, replaying the exact queries the extension builds, graded against the producer name from Systembolaget's API (ground truth the matcher never sees) — showed the earlier leading-brand-token gate was patching the wrong layer.

**Root cause: the explore endpoint, not the gate.** `/api/explore/explore` is a marketplace browser with weak text relevance. It misses even top-selling wines (Casillero del Diablo Cabernet Sauvignon, El Coto Crianza return only other producers' wines; 33/90 audited products got zero candidates), so the matcher was choosing among wrong candidates no gate could rescue. The "Onbrina is not on Vivino" premise of the previous commit was wrong too — it simply isn't in the marketplace index.

**Change:** query Vivino's own search backend — the Algolia `WINES_prod` index, with the public search-only credentials Vivino ships to anonymous visitors (the exact pattern already used for Untappd). Its hits carry the winery as a separate field, which replaces brand-token guessing with a real producer check:

- Accept requires every distinctive winery token in the query, skipping corporate-form words (Weingut/Bodegas/Château/…). Any-token overlap would let "Knight Black Horse" pass for "Black Knight"; the leading-token rule failed on style-first titles ("Etna Rosso Terre dei Miti"), generic prefixes ("Château Dereszla" auto-matched Château **Pajzos**, "Viña Maipo" → Viña **Zorzal**), and one-letter brands ("R Riesling Organic" → a random organic Riesling).
- The check runs down the ranking, not only on rank 1: a confirmed producer at rank 3 beats an unconfirmable namesake at rank 1 (Mionetto's own prosecco vs Masottina's).
- Titles that omit the producer ("Barbera d'Alba Busije" is by Giacosa Fratelli) can match on an exact name — case/diacritics/punctuation folded — but only when the name is rare index-wide (nbHits ≤ 20). "Piemonte Barbera" exists verbatim under many producers (1714 hits) and stays Uncertain. A similarity threshold can't replace exactness: compareTwoStrings ignores whitespace and scores "Riesling Organic" 0.97 against "R Riesling Organic".
- Ratings are wine-level (all vintages pooled — the query drops the vintage anyway); links go to the most-rated vintage id, falling back to `/w/{wine id}`.

**Audit, same 90 products replayed:**

| | before (explore + leading token) | after |
|---|---|---|
| correct auto-matches | 16 | 65 |
| wrong-producer auto-matches | 9 | 0 |
| no candidates at all | 33 | 0 |

Remaining known limitation: a same-producer sibling cuvée can still be accepted (3/69 accepts, e.g. Pizzolato's Spumante Dry for their Spumante Rosé) — the title rarely distinguishes them, and the failure is a rating from the right producer's adjacent wine.

The mocked test suite was rewritten for the Algolia shape; every failure class above has a pinned regression test (28 tests, all passing, including live lookups). Manifest host permissions and CSP gained `9takgwjuxl-dsn.algolia.net`.