### PR TITLE
fix: don't flag bottles as non-bottle on pages with a packaging dropdown

### DIFF
--- a/src/components/productUtils.ts
+++ b/src/components/productUtils.ts
@@ -89,8 +89,12 @@ export function isBottle(): boolean {
     return true
   }
 
-  const descriptor = getPackagingDescriptor(main)
-  // If we can't read the format line, assume bottle rather than block the rating.
+  const productId = getProductId()
+  const descriptor =
+    (productId ? getPackagingFromPageData(productId) : null) ??
+    getSelectedPackaging(main) ??
+    getPackagingDescriptor(main)
+  // If we can't read the packaging, assume bottle rather than block the rating.
   if (!descriptor) {
     return true
   }
@@ -117,18 +121,84 @@ function getPackagingDescriptor(main: HTMLElement): null | string {
     return null
   }
 
+  let formatLine: HTMLElement | null = null
   let node: HTMLElement | null = volumeLeaf as HTMLElement
   for (let i = 0; i < 4 && node; i++) {
     const text = node.textContent
     if (/[·•]/.test(text) && /\d/.test(text) && text.length < 80) {
+      formatLine = node
       break
     }
     node = node.parentElement
   }
-  if (!node) {
+  // No compact format line near the alcohol content (products with a packaging
+  // dropdown only render "{alcohol} % vol."). Never fall back to a larger
+  // container — its text can contain words like "fatkaraktär" that
+  // false-match the non-bottle list.
+  if (!formatLine) {
     return null
   }
 
-  const firstSegment = node.textContent.split(/[·•]/)[0].trim().toLowerCase()
+  const firstSegment = formatLine.textContent
+    .split(/[·•]/)[0]
+    .trim()
+    .toLowerCase()
   return firstSegment ? firstSegment : null
+}
+
+// Systembolaget embeds the product data of the initially loaded page in
+// Next.js' __NEXT_DATA__ script; "packagingLevel1" is the packaging name
+// ("Flaska", "Box", …). Only trust it when an entry matches the current
+// product id — SPA navigations don't refresh the script.
+function getPackagingFromPageData(productId: string): null | string {
+  const raw = document.getElementById('__NEXT_DATA__')?.textContent
+  if (!raw) {
+    return null
+  }
+
+  let fallback: Record<string, unknown>
+  try {
+    const parsed = JSON.parse(raw) as {
+      props?: { pageProps?: { fallback?: Record<string, unknown> } }
+    }
+    fallback = parsed.props?.pageProps?.fallback ?? {}
+  } catch {
+    return null
+  }
+
+  for (const entry of Object.values(fallback)) {
+    if (typeof entry !== 'object' || entry === null) {
+      continue
+    }
+    const product = entry as {
+      packagingLevel1?: null | string
+      productNumber?: null | string
+    }
+    if (product.productNumber !== productId) {
+      continue
+    }
+    const packaging = product.packagingLevel1
+    return typeof packaging === 'string' && packaging
+      ? packaging.toLowerCase()
+      : null
+  }
+  return null
+}
+
+// Products sold in several packagings replace the static format line with a
+// dropdown whose selected value reads "{packaging}, {volume} ml". Read the
+// current selection; requiring a volume keeps unrelated dropdowns (store
+// picker, quantity, …) from being mistaken for it.
+function getSelectedPackaging(main: HTMLElement): null | string {
+  for (const el of main.querySelectorAll('select, [role="combobox"]')) {
+    // The dropdown's hidden <select> has no options until the app hydrates,
+    // so the selected option can be undefined despite its non-nullish type.
+    const source = el instanceof HTMLSelectElement ? el.selectedOptions[0] : el
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    const text = source?.textContent.trim().toLowerCase() ?? ''
+    if (/\d\s*(cl|l|ml)\b/.test(text)) {
+      return text
+    }
+  }
+  return null
 }


### PR DESCRIPTION
Products sold in several sizes (e.g. capitel-de-roari-1236602) no longer
render the compact "{packaging} · {volume} · {alcohol} % vol." format
line — the packaging moved into a dropdown and only "15 % vol." remains
as static text. getPackagingDescriptor's ancestor climb then never found
a format line, but silently fell through to the 4th ancestor: the whole
product-info column. Its text has no "·" either, so the entire column
text became the "packaging descriptor", and taste descriptions like
"utvecklad smak med fatkaraktär" substring-matched the blocklisted
'fat', showing "Vinet är inte på flaska" for a plain bottle.

- getPackagingDescriptor now returns null unless an ancestor actually
  matched the format-line heuristic, instead of guessing from a
  container blob.
- Read the packaging from Next.js' __NEXT_DATA__ (packagingLevel1) when
  it has an entry for the current product id — ground truth on full
  page loads.
- Otherwise read the selected value of the packaging dropdown
  ("Flaska, 375 ml" / "Box, 3000 ml"), gated on containing a volume so
  unrelated dropdowns aren't mistaken for it — covers SPA navigations
  where __NEXT_DATA__ is stale.
- Still assume bottle when no source can be read.

Verified against the live page markup for all layouts (format line,
dropdown SSR, dropdown hydrated, box variants) in a Chromium harness.

Fixes #115

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UDPEPBW8WX5cuRNPeQT8U7