### PR TITLE
fix: anchor list-card ratings on the product-number line, not hashed classes

### DIFF
--- a/src/components/domUtils.ts
+++ b/src/components/domUtils.ts
@@ -440,27 +440,32 @@ function generateCapSvg(rating: number): string {
 
 const CARD_RATING_CLASS = 'bp-card-rating'
 
-export function injectCardSpinner(card: Element): HTMLElement | null {
+export function injectCardSpinner(
+  card: Element,
+  productId: string
+): HTMLElement | null {
   if (card.querySelector(`.${CARD_RATING_CLASS}, .bp-card-spinner-inline`)) {
     return null
   }
   ensureStyles()
-  const lastNameSpan = [...card.querySelectorAll('.monopol-250')].at(-1)
-  if (!lastNameSpan) return null
+  const anchor = findCardAnchor(card, productId)
+  if (!anchor) return null
 
   const spinner = document.createElement('div')
   spinner.className = 'bp-card-spinner-inline'
-  lastNameSpan.insertAdjacentElement('afterend', spinner)
+  anchor.insertAdjacentElement('afterend', spinner)
   return spinner
 }
 
 export function replaceCardSpinner(
+  card: Element,
   spinner: HTMLElement,
+  productId: string,
   productType: ProductType,
   rating: RatingResponse
 ): void {
+  spinner.remove()
   if (rating.status !== RatingResultStatus.Found) {
-    spinner.remove()
     return
   }
   const svg =
@@ -474,7 +479,37 @@ export function replaceCardSpinner(
     <span class="bp-card-score">${rating.rating.toString()}</span>
     <span class="bp-card-votes">(${rating.votes.toString()})</span>
   `
-  spinner.replaceWith(badge)
+  // The SPA may have re-rendered the card's contents while the rating request
+  // was in flight, detaching the spinner — so re-resolve the anchor instead of
+  // replacing a node that may no longer be in the card.
+  if (card.querySelector(`.${CARD_RATING_CLASS}`)) return
+  findCardAnchor(card, productId)?.insertAdjacentElement('afterend', badge)
+}
+
+// Finds the element rendering the "Nr {productId}" line on a list card.
+// Systembolaget's class names are hashed build artifacts that reshuffle
+// between deploys, so the product-number text is the only stable anchor.
+function findCardAnchor(card: Element, productId: string): Element | null {
+  const nrPattern = new RegExp(`^Nr\\s*${productId}$`)
+  const matchesNr = (el: Element) =>
+    nrPattern.test(el.textContent.replace(/\s+/g, ' ').trim())
+
+  let anchor: Element | null = null
+  for (const el of card.querySelectorAll('*')) {
+    if (matchesNr(el)) anchor = el
+  }
+  if (!anchor) return null
+
+  // Climb to the outermost element that renders only the "Nr …" line, so the
+  // badge is inserted as a sibling block below it rather than inside it.
+  while (
+    anchor.parentElement &&
+    anchor.parentElement !== card &&
+    matchesNr(anchor.parentElement)
+  ) {
+    anchor = anchor.parentElement
+  }
+  return anchor
 }
 
 function generateStarsSvg(rating: number): string {

--- a/src/components/productUtils.ts
+++ b/src/components/productUtils.ts
@@ -1,12 +1,36 @@
 import { ProductType } from '@/@types/types'
 
+// The category line shown above the product name on list cards
+// ("Vitt vin, Friskt & fruktigt", "Öl, Ljus lager, …") — it must not leak
+// into the search query sent to Vivino/Untappd.
+const CATEGORY_LINE =
+  /^(blanddryck|cider|mousserande|rosé|rött vin|vin|vitt vin|öl)[^,]*,/i
+
 export function getCardName(card: Element): null | string {
-  const spans = [...card.querySelectorAll('.monopol-250')] as HTMLElement[]
-  if (spans.length === 0) return null
-  const parts = spans.map((s) => s.innerText.trim()).filter(Boolean)
+  const productId = getCardProductId(card)
+  if (!productId) return null
+
+  // Anchor on the "Nr {productId}" line every card renders; the name and
+  // subtitle/vintage are the lines directly above it. Systembolaget's class
+  // names are hashed build artifacts (monopol-*, css-*) and reshuffle
+  // between deploys, so text structure is the only stable thing to hold on to.
+  const lines = (card as HTMLElement).innerText
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+  const nrPattern = new RegExp(`^Nr\\s*${productId}$`)
+  const nrIndex = lines.findIndex((line) => nrPattern.test(line))
+  if (nrIndex <= 0) return null
+
+  let titleLines = lines.slice(Math.max(0, nrIndex - 2), nrIndex)
+  if (titleLines.length > 1 && CATEGORY_LINE.test(titleLines[0])) {
+    titleLines = titleLines.slice(1)
+  }
+  if (titleLines.some((line) => CATEGORY_LINE.test(line))) return null
+
   // Normalize ", 2025" → " 2025" so vintage year is included without comma
   return (
-    parts
+    titleLines
       .join(' ')
       .replace(/,\s*(\d{4})/, ' $1')
       .trim() || null

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -70,11 +70,11 @@ async function handleListCard(card: Element) {
   const name = productUtils.getCardName(card)
   if (!productId || !name) return
 
-  const spinner = domUtils.injectCardSpinner(card)
+  const spinner = domUtils.injectCardSpinner(card, productId)
   if (!spinner) return
 
   const rating = await enqueueListFetch(productId, name, productType)
-  domUtils.replaceCardSpinner(spinner, productType, rating)
+  domUtils.replaceCardSpinner(card, spinner, productId, productType, rating)
 }
 
 function handleRating(productType: ProductType, rating: RatingResponse) {


### PR DESCRIPTION
## Problem

Ratings on `/sortiment/` list pages stopped showing up, and after navigating back they rendered in the corner of the card, on top of the black Sektion/Hylla shelf badges.

The list-card code anchored on Systembolaget's `.monopol-250` class — both to extract the product name (join all matching spans) and to place the badge (after the *last* matching span). But `monopol-250` is a hashed typography-scale utility from their design system (it appears on footer headings, shelf-badge numbers, etc.), and its usage reshuffles between site deploys. On the current markup the last match inside a card is the shelf number in the Sektion/Hylla corner badge, so the rating was inserted there; on cards with no match, nothing rendered at all.

## Fix

Re-anchor on the one stable thing every card renders: the `Nr {productId}` line. The id is already known from the tile's `href`, so the anchor is deterministic and survives class-name reshuffles.

- `getCardName` reads the card's `innerText` lines directly above the product-number line (name + subtitle/vintage) and filters out the category line ("Vitt vin, Friskt & fruktigt") so it can't leak into the Vivino/Untappd search query
- `injectCardSpinner` / `replaceCardSpinner` insert the spinner/badge right after the outermost element rendering the product-number line
- `replaceCardSpinner` re-resolves the anchor instead of calling `replaceWith` on the spinner node, so an SPA re-render of the card's contents while the rating request is in flight no longer swallows the badge

## Testing

- `pnpm compile`, `pnpm lint`, `pnpm ft:check`, `pnpm build:chrome` all pass
- Ran the new extraction/anchoring logic in headless Chromium against synthetic tiles modeling both card layouts (plain list card, and the store view where the Sektion/Hylla numbers carry `monopol-250`): names extract correctly ("Inycon Fiano Chardonnay 2025", "Tuborg Classic", subtitle-less "Contacto") and the badge always lands after the "Nr …" line, never in the corner
- The live-site Playwright suite couldn't run from this environment (no network access to systembolaget.se) — worth a manual check on `https://www.systembolaget.se/sortiment/vin/` with the built extension before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB8pNjcAP9Dk4MYkagGa8g