### PR TITLE
Bump version from 1.3.0 to 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bolaget-plus",
   "description": "Bolaget+ is a browser extension that adds more features to Systembolaget's website.",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "author": "BroadcastDivers",
   "scripts": {


### PR DESCRIPTION
Releases v1.3.1, picking up the fixes merged since 1.3.0:

- #117 — anchor list-card ratings on the product-number line, not hashed classes (list-page ratings missing / rendering over the Sektion/Hylla corner badges)
- #116 — don't flag bottles as non-bottle on pages with a packaging dropdown

Merging this triggers the deploy workflow: store submission (Chrome + Firefox) and the `v1.3.1` GitHub release with the packaged zips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MB8pNjcAP9Dk4MYkagGa8g

---
_Generated by [Claude Code](https://claude.ai/code/session_01MB8pNjcAP9Dk4MYkagGa8g)_