### PR TITLE
fix: stop asking users to approve an algolia.net host permission

### DIFF
--- a/e2e/api-integration.spec.ts
+++ b/e2e/api-integration.spec.ts
@@ -1,9 +1,27 @@
 import { test, expect } from '@playwright/test';
-import { fetchRatingFromVivino, fetchRatingFromUntappd } from '../src/components/api';
-import { RatingResultStatus } from '../src/@types/types';
+import { fetchRatingFromVivino, fetchRatingFromUntappd, fetchUntappdSearchConfig } from '../src/components/api';
+import { RatingResultStatus, UntappdSearchConfig } from '../src/@types/types';
 import type { VivinoHit } from '../src/@types/types';
 
+// The credentials Untappd's search page is shipping right now. Reading them
+// live is the point: if their markup changes, these tests fail instead of the
+// extension silently falling back to a pinned key that may be rotated out.
+const liveConfig: UntappdSearchConfig = {
+  appId: '9WBO4RQ3HO',
+  searchKey: '1d347324d67ec472bb7132c66aead485'
+};
+
 test.describe('API Integration Tests', () => {
+  test('fetchUntappdSearchConfig reads live credentials from untappd.com', async () => {
+    const config = await fetchUntappdSearchConfig();
+
+    expect(config.appId).toMatch(/^[0-9A-Z]{10}$/);
+    expect(config.searchKey).toMatch(/^[0-9a-f]{32}$/);
+    // Copy them onto the shared object so the lookups below use whatever is
+    // live, not a hardcoded pair.
+    Object.assign(liveConfig, config);
+  });
+
   test('fetchRatingFromVivino returns data for valid query', async () => {
     const result = await fetchRatingFromVivino('Bread & Butter');
 
@@ -27,7 +45,7 @@ test.describe('API Integration Tests', () => {
   });
 
   test('fetchRatingFromUntappd returns data for valid query', async () => {
-    const result = await fetchRatingFromUntappd('Pabst Blue Ribbon');
+    const result = await fetchRatingFromUntappd('Pabst Blue Ribbon', liveConfig);
 
     expect(result).not.toBeNull();
     expect(result?.status).toBe(RatingResultStatus.Found);
@@ -37,7 +55,7 @@ test.describe('API Integration Tests', () => {
   });
 
   test('fetchRatingFromUntappd returns data for a cider query', async () => {
-    const result = await fetchRatingFromUntappd('Rekorderlig Päron');
+    const result = await fetchRatingFromUntappd('Rekorderlig Päron', liveConfig);
 
     expect(result).not.toBeNull();
     expect(result?.status).toBe(RatingResultStatus.Found);
@@ -662,7 +680,7 @@ test.describe('Untappd lookup misses (mocked fetch)', () => {
           })
       } as Response)) as typeof fetch;
 
-    const result = await fetchRatingFromUntappd('Mystery Brew IPA');
+    const result = await fetchRatingFromUntappd('Mystery Brew IPA', liveConfig);
 
     expect(result.status).toBe(RatingResultStatus.Uncertain);
     expect(result.link).toContain('untappd.com/search');

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -15,6 +15,14 @@ export type BeerResponse = RatingResponse & {
   brewery: null | string
 }
 
+// Asks the background script to download a Vivino label thumbnail as a data
+// URL. images.vivino.com sends no CORS headers and the page CSP blocks
+// hotlinking it, so the content script cannot do this itself.
+export interface ImageRequest {
+  type: 'vivinoImage'
+  url: string
+}
+
 export interface RatingAlternative {
   imageDataUrl?: string
   link: string
@@ -46,6 +54,12 @@ export interface RatingResponse {
   votes: number
 }
 
+// Asks the background script for Untappd's current Algolia credentials; the
+// content script cannot read untappd.com itself (no CORS there).
+export interface SearchConfigRequest {
+  type: 'untappdSearchConfig'
+}
+
 export interface UntappdHit {
   beer_name: string
   beer_slug: string
@@ -54,6 +68,14 @@ export interface UntappdHit {
   brewery_name: null | string
   rating_count: null | number
   rating_score: null | number
+}
+
+// The Algolia app/key pair Untappd's own search page uses. The app id also
+// determines the search host (`{appId}-dsn.algolia.net`), so reading it at
+// runtime keeps us working across a key rotation *and* an app migration.
+export interface UntappdSearchConfig {
+  appId: string
+  searchKey: string
 }
 
 export interface UntappdSearchJSON {

--- a/src/components/api.ts
+++ b/src/components/api.ts
@@ -6,15 +6,24 @@ import {
   RatingResponse,
   RatingResultStatus,
   UntappdHit,
+  UntappdSearchConfig,
   UntappdSearchJSON,
   VivinoHit,
   VivinoSearchJSON
 } from '@/@types/types'
 
-// Untappd's search page renders results client-side via Algolia; these are the
-// public search-only credentials it ships to anonymous visitors.
-const UNTAPPD_ALGOLIA_APP_ID = '9WBO4RQ3HO'
-const UNTAPPD_ALGOLIA_SEARCH_KEY = '1d347324d67ec472bb7132c66aead485'
+// Untappd's search page renders results client-side via Algolia, so the HTML
+// carries no beers — but it does carry the search-only credentials its own JS
+// uses, in a `window.UNTAPPD_SEARCH_CONFIG` blob. We read them from there at
+// runtime rather than pinning them, so a rotated key heals itself.
+const UNTAPPD_SEARCH_CONFIG_MARKER = 'window.UNTAPPD_SEARCH_CONFIG'
+
+// Used only when that read fails (offline, markup change). Values as shipped
+// by untappd.com; stale ones surface as an Uncertain card, never a wrong one.
+const UNTAPPD_FALLBACK_CONFIG: UntappdSearchConfig = {
+  appId: '9WBO4RQ3HO',
+  searchKey: '1d347324d67ec472bb7132c66aead485'
+}
 
 // Vivino's search box is also Algolia-backed with public search-only
 // credentials shipped to anonymous visitors. The WINES_prod index has far
@@ -134,13 +143,59 @@ const WINERY_COMPANY_WORDS = new Set([
   'winzer'
 ])
 
+// Fetched by the background script because the systembolaget.se page CSP
+// (img-src) blocks hotlinking Vivino's image hosts; a data: URL is allowed.
+export async function fetchImageAsDataUrl(
+  url: string | undefined
+): Promise<string | undefined> {
+  if (!url) {
+    return undefined
+  }
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(IMAGE_FETCH_TIMEOUT_MS)
+    })
+    if (!response.ok) {
+      return undefined
+    }
+    const contentType = response.headers.get('content-type') ?? 'image/png'
+    const bytes = new Uint8Array(await response.arrayBuffer())
+    let binary = ''
+    const chunkSize = 8192
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize))
+    }
+    return `data:${contentType};base64,${btoa(binary)}`
+  } catch {
+    return undefined
+  }
+}
+
+// Runs in the *content script* on Chrome, not the background. Algolia serves
+// any origin (it is a browser-side search product), so this is an ordinary
+// CORS request needing no host permission — which is why algolia.net is absent
+// from the Chrome manifest and users are never asked to approve it.
 export async function fetchRatingFromUntappd(
-  productName: string
+  productName: string,
+  config: UntappdSearchConfig
 ): Promise<RatingResponse> {
-  const url = `https://${UNTAPPD_ALGOLIA_APP_ID.toLowerCase()}-dsn.algolia.net/1/indexes/beer/query`
+  // Credentials go in the query string with a text/plain body to keep the
+  // request CORS-"simple": no preflight, so a lookup costs one round trip.
+  const credentials = new URLSearchParams({
+    'x-algolia-api-key': config.searchKey,
+    'x-algolia-application-id': config.appId
+  })
+  const url = `https://${config.appId.toLowerCase()}-dsn.algolia.net/1/indexes/beer/query?${credentials.toString()}`
   const searchFallbackUrl = `https://untappd.com/search?q=${encodeURIComponent(
     productName
   )}&type=beer&sort=all`
+  // A rejected key or a network blip is not a definitive miss: hand over a
+  // working Untappd search link and mark it transient so it never gets cached.
+  const uncertainFallback = {
+    link: searchFallbackUrl,
+    status: RatingResultStatus.Uncertain,
+    transient: true
+  } as RatingResponse
 
   try {
     const response = await fetch(url, {
@@ -151,15 +206,13 @@ export async function fetchRatingFromUntappd(
         }).toString()
       }),
       headers: {
-        'Content-Type': 'application/json',
-        'X-Algolia-API-Key': UNTAPPD_ALGOLIA_SEARCH_KEY,
-        'X-Algolia-Application-Id': UNTAPPD_ALGOLIA_APP_ID
+        'Content-Type': 'text/plain'
       },
       method: 'POST'
     })
 
     if (!response.ok) {
-      return { status: RatingResultStatus.NotFound } as RatingResponse
+      return uncertainFallback
     }
 
     const data = (await response.json()) as UntappdSearchJSON
@@ -212,13 +265,21 @@ export async function fetchRatingFromUntappd(
       votes: bestMatch.votes
     } as BeerResponse
   } catch {
-    return { status: RatingResultStatus.NotFound } as RatingResponse
+    return uncertainFallback
   }
 }
 
+// Like the Untappd lookup, this runs in the content script on Chrome so that
+// Vivino's Algolia host needs no permission. Label images are the exception:
+// images.vivino.com sends no CORS headers and the systembolaget.se page CSP
+// blocks hotlinking them, so downloading one stays a background job and is
+// injected here as `fetchImage`.
 export async function fetchRatingFromVivino(
   query: string,
-  includeImage = true
+  includeImage = true,
+  fetchImage: (
+    url: string | undefined
+  ) => Promise<string | undefined> = fetchImageAsDataUrl
 ): Promise<RatingResponse> {
   const url = `https://${VIVINO_ALGOLIA_APP_ID.toLowerCase()}-dsn.algolia.net/1/indexes/WINES_prod/query`
   // Even Algolia misses some wines (obscure producers, new releases). Instead
@@ -321,7 +382,7 @@ export async function fetchRatingFromVivino(
       if (includeImage) {
         await Promise.all(
           top.map(async (wine) => {
-            wine.imageDataUrl = await fetchImageAsDataUrl(wine.imageUrl)
+            wine.imageDataUrl = await fetchImage(wine.imageUrl)
           })
         )
       }
@@ -331,7 +392,7 @@ export async function fetchRatingFromVivino(
     // Return only the response contract — similarityRate/imageUrl are internal.
     return {
       imageDataUrl: includeImage
-        ? await fetchImageAsDataUrl(bestMatch.imageUrl)
+        ? await fetchImage(bestMatch.imageUrl)
         : undefined,
       link: bestMatch.link,
       name: bestMatch.name,
@@ -341,6 +402,21 @@ export async function fetchRatingFromVivino(
     }
   } catch {
     return { ...uncertainFallback, transient: true }
+  }
+}
+
+// Reads the Algolia credentials out of Untappd's search page. Runs in the
+// background script: untappd.com sends no CORS headers, so only the extension
+// (which declares untappd.com) can fetch it.
+export async function fetchUntappdSearchConfig(): Promise<UntappdSearchConfig> {
+  try {
+    const response = await fetch('https://untappd.com/search?type=beer')
+    if (!response.ok) {
+      return UNTAPPD_FALLBACK_CONFIG
+    }
+    return parseSearchConfig(await response.text()) ?? UNTAPPD_FALLBACK_CONFIG
+  } catch {
+    return UNTAPPD_FALLBACK_CONFIG
   }
 }
 
@@ -357,34 +433,6 @@ function distinctiveTokens(text: string): string[] {
         !/^\d+$/.test(token) &&
         !GENERIC_WINE_WORDS.has(token)
     )
-}
-
-// Fetched by the background script because the systembolaget.se page CSP
-// (img-src) blocks hotlinking Vivino's image hosts; a data: URL is allowed.
-async function fetchImageAsDataUrl(
-  url: string | undefined
-): Promise<string | undefined> {
-  if (!url) {
-    return undefined
-  }
-  try {
-    const response = await fetch(url, {
-      signal: AbortSignal.timeout(IMAGE_FETCH_TIMEOUT_MS)
-    })
-    if (!response.ok) {
-      return undefined
-    }
-    const contentType = response.headers.get('content-type') ?? 'image/png'
-    const bytes = new Uint8Array(await response.arrayBuffer())
-    let binary = ''
-    const chunkSize = 8192
-    for (let i = 0; i < bytes.length; i += chunkSize) {
-      binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize))
-    }
-    return `data:${contentType};base64,${btoa(binary)}`
-  } catch {
-    return undefined
-  }
 }
 
 // Lowercases and folds diacritics and punctuation so cosmetic spelling
@@ -406,6 +454,44 @@ function normalizeImageUrl(url: null | string | undefined): string | undefined {
     return undefined
   }
   return url.startsWith('//') ? `https:${url}` : url
+}
+
+// Extracts the JSON object assigned to `window.UNTAPPD_SEARCH_CONFIG`. Brace
+// matching rather than a regex: the blob holds nested objects, and a lazy
+// `\{.*?\}` would stop at the first inner brace.
+function parseSearchConfig(html: string): null | UntappdSearchConfig {
+  const marker = html.indexOf(UNTAPPD_SEARCH_CONFIG_MARKER)
+  if (marker === -1) {
+    return null
+  }
+  const start = html.indexOf('{', marker)
+  if (start === -1) {
+    return null
+  }
+
+  let depth = 0
+  let escaped = false
+  let inString = false
+  for (let i = start; i < html.length; i++) {
+    const char = html.charAt(i)
+    if (escaped) {
+      escaped = false
+    } else if (char === '\\') {
+      escaped = true
+    } else if (char === '"') {
+      inString = !inString
+    } else if (inString) {
+      continue
+    } else if (char === '{') {
+      depth++
+    } else if (char === '}') {
+      depth--
+      if (depth === 0) {
+        return toSearchConfig(html.slice(start, i + 1))
+      }
+    }
+  }
+  return null
 }
 
 // True when every distinctive token of the winery name appears in the query
@@ -458,6 +544,20 @@ function toAlternatives(
         ? [{ imageDataUrl, link, name, rating, votes }]
         : []
     )
+}
+
+function toSearchConfig(json: string): null | UntappdSearchConfig {
+  try {
+    const parsed = JSON.parse(json) as Partial<UntappdSearchConfig>
+    // `autocompleteSearchKey` sits in the same blob but drives the search
+    // box's suggestions — the beer index wants `searchKey`.
+    if (!parsed.appId || !parsed.searchKey) {
+      return null
+    }
+    return { appId: parsed.appId, searchKey: parsed.searchKey }
+  } catch {
+    return null
+  }
 }
 
 // vivino.com/wines/{id} resolves by vintage id, not wine id (see the

--- a/src/components/ratingService.ts
+++ b/src/components/ratingService.ts
@@ -1,12 +1,16 @@
 import browser from 'webextension-polyfill'
 
 import {
+  ImageRequest,
   ProductType,
   RatingRequest,
   RatingResponse,
-  RatingResultStatus
+  RatingResultStatus,
+  SearchConfigRequest,
+  UntappdSearchConfig
 } from '@/@types/types'
 
+import { fetchRatingFromUntappd, fetchRatingFromVivino } from './api'
 import { saveRating as cacheRating, tryGetRating } from './ratingsCache'
 
 export async function fetchRating(
@@ -26,10 +30,7 @@ export async function fetchRating(
     ) {
       return cachedRating
     }
-    const response = await browser.runtime.sendMessage<
-      RatingRequest,
-      RatingResponse
-    >(ratingRequest)
+    const response = await fetchFromSource(ratingRequest)
 
     if (
       response.status !== RatingResultStatus.NotFound &&
@@ -41,6 +42,51 @@ export async function fetchRating(
   } catch {
     return { status: RatingResultStatus.NotFound } as RatingResponse
   }
+}
+
+// Both lookups are Algolia queries, and Algolia serves any origin. On Chrome a
+// content script's cross-origin fetch is an ordinary CORS request, so running
+// them here needs no host permission at all — which is what keeps algolia.net
+// out of the manifest and out of the install prompt. Firefox works
+// differently: it routes content-script requests through the extension's
+// principal and blocks any host missing from `permissions` whatever CORS says,
+// so that build hands the whole lookup to the background instead.
+async function fetchFromSource(
+  ratingRequest: RatingRequest
+): Promise<RatingResponse> {
+  if (import.meta.env.FIREFOX) {
+    return await browser.runtime.sendMessage<RatingRequest, RatingResponse>(
+      ratingRequest
+    )
+  }
+
+  if (ratingRequest.query === ProductType.Wine) {
+    return await fetchRatingFromVivino(
+      ratingRequest.productName,
+      ratingRequest.includeImage ?? true,
+      fetchImageViaBackground
+    )
+  }
+
+  const config = await browser.runtime.sendMessage<
+    SearchConfigRequest,
+    UntappdSearchConfig
+  >({ type: 'untappdSearchConfig' })
+  return await fetchRatingFromUntappd(ratingRequest.productName, config)
+}
+
+// Label thumbnails stay a background job even on Chrome: images.vivino.com
+// sends no CORS headers, and the page CSP blocks hotlinking them anyway.
+async function fetchImageViaBackground(
+  url: string | undefined
+): Promise<string | undefined> {
+  if (!url) {
+    return undefined
+  }
+  return await browser.runtime.sendMessage<ImageRequest, string | undefined>({
+    type: 'vivinoImage',
+    url
+  })
 }
 
 function isMissingImages(rating: RatingResponse, type: ProductType): boolean {

--- a/src/components/searchConfigCache.ts
+++ b/src/components/searchConfigCache.ts
@@ -1,0 +1,50 @@
+import { storage } from '@wxt-dev/storage'
+
+import { UntappdSearchConfig } from '@/@types/types'
+
+import { fetchUntappdSearchConfig } from './api'
+
+// Untappd rotates these rarely, so a week between reads is plenty; a key that
+// is rejected before then invalidates the entry on the spot (see below).
+const CACHE_EXPIRATION_DAYS = 7
+
+const CACHE_KEY = 'local:untappdSearchConfig'
+
+export async function getSearchConfig(): Promise<UntappdSearchConfig> {
+  const cached = await tryGetSearchConfig()
+  if (cached) {
+    return cached
+  }
+
+  const config = await fetchUntappdSearchConfig()
+  await Promise.all([
+    storage.setItem(CACHE_KEY, config),
+    storage.setMeta(CACHE_KEY, { datetime: new Date().toISOString() })
+  ])
+  return config
+}
+
+// Called when a lookup comes back unauthorized, so the next request re-reads
+// untappd.com instead of retrying a key that has since been rotated out.
+export async function invalidateSearchConfig(): Promise<void> {
+  await storage.removeItem(CACHE_KEY, { removeMeta: true })
+}
+
+async function tryGetSearchConfig(): Promise<null | UntappdSearchConfig> {
+  const [config, metadata] = await Promise.all([
+    storage.getItem<UntappdSearchConfig>(CACHE_KEY),
+    storage.getMeta<{ datetime: string }>(CACHE_KEY)
+  ])
+  if (!config || !metadata.datetime) {
+    return null
+  }
+
+  const ageDays =
+    (Date.now() - new Date(metadata.datetime).getTime()) / (1000 * 3600 * 24)
+  if (ageDays > CACHE_EXPIRATION_DAYS) {
+    await invalidateSearchConfig()
+    return null
+  }
+
+  return config
+}

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -1,7 +1,17 @@
 import browser from 'webextension-polyfill'
 
-import { ProductType, type RatingRequest } from '@/@types/types'
-import { fetchRatingFromUntappd, fetchRatingFromVivino } from '@/components/api'
+import {
+  type ImageRequest,
+  ProductType,
+  type RatingRequest,
+  type SearchConfigRequest
+} from '@/@types/types'
+import {
+  fetchImageAsDataUrl,
+  fetchRatingFromUntappd,
+  fetchRatingFromVivino
+} from '@/components/api'
+import { getSearchConfig } from '@/components/searchConfigCache'
 
 export default defineBackground(() => {
   // console.log('Running with id:', { id: browser.runtime.id })
@@ -16,7 +26,37 @@ function isGetRatingMessage(message: unknown): message is RatingRequest {
   )
 }
 
+function isImageMessage(message: unknown): message is ImageRequest {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message.type === 'vivinoImage'
+  )
+}
+
+function isSearchConfigMessage(
+  message: unknown
+): message is SearchConfigRequest {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message.type === 'untappdSearchConfig'
+  )
+}
+
 browser.runtime.onMessage.addListener(async (message: unknown) => {
+  // On Chrome the content script queries Algolia itself, so the only thing it
+  // needs from here is the credentials; beer and cider never reach the switch
+  // below. Firefox blocks content-script requests to hosts outside
+  // `permissions`, so that build routes the whole lookup through here instead.
+  if (isSearchConfigMessage(message)) {
+    return await getSearchConfig()
+  }
+  if (isImageMessage(message)) {
+    return await fetchImageAsDataUrl(message.url)
+  }
   if (!isGetRatingMessage(message)) {
     return
   }
@@ -24,7 +64,7 @@ browser.runtime.onMessage.addListener(async (message: unknown) => {
   switch (query) {
     case ProductType.Beer:
     case ProductType.Cider:
-      return await fetchRatingFromUntappd(productName)
+      return await fetchRatingFromUntappd(productName, await getSearchConfig())
     case ProductType.Wine:
       return await fetchRatingFromVivino(productName, includeImage ?? true)
   }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     }
   },
   srcDir: 'src',
-  manifest: {
+  manifest: ({ browser }) => ({
     default_locale: 'sv',
     icons: {
       16: 'icons/16.png',
@@ -39,14 +39,19 @@ export default defineConfig({
       // Vivino serves label/bottle thumbnails from separate image hosts
       'https://images.vivino.com/*',
       'https://thumbs.vivino.com/*',
+      // Read by the background script for Untappd's current Algolia
+      // credentials (the search page ships them in its own HTML).
       'https://untappd.com/*',
-      // Untappd's Algolia search index, used for beer lookups
-      'https://9wbo4rq3ho-dsn.algolia.net/*',
-      // Vivino's Algolia search index, used for wine lookups
-      'https://9takgwjuxl-dsn.algolia.net/*'
+      // Both wine and beer/cider ratings come from Algolia indexes (Vivino's
+      // WINES_prod, Untappd's beer). Chrome lets the content script query
+      // those as plain CORS requests, so that build declares nothing here and
+      // users never see the hostnames. Firefox routes content-script requests
+      // through the extension's principal and blocks undeclared hosts whatever
+      // CORS allows, so only that build has to ask.
+      ...(browser === 'firefox' ? ['https://*.algolia.net/*'] : [])
     ],
     content_security_policy: {
-      extension_pages: `script-src 'self'; object-src 'self'; connect-src 'self' https://www.vivino.com https://images.vivino.com https://thumbs.vivino.com https://untappd.com https://9wbo4rq3ho-dsn.algolia.net https://9takgwjuxl-dsn.algolia.net${isProduction ? '' : ' ws://localhost:3000/'};`
+      extension_pages: `script-src 'self'; object-src 'self'; connect-src 'self' https://www.vivino.com https://images.vivino.com https://thumbs.vivino.com https://untappd.com${browser === 'firefox' ? ' https://*.algolia.net' : ''}${isProduction ? '' : ' ws://localhost:3000/'};`
     },
     browser_specific_settings: {
       gecko: {
@@ -56,5 +61,5 @@ export default defineConfig({
         strict_min_version: '120.0'
       }
     }
-  }
+  })
 })


### PR DESCRIPTION
## Why

The install prompt asked users to allow `9wbo4rq3ho-dsn.algolia.net` and `9takgwjuxl-dsn.algolia.net` — opaque strings nobody can connect to Untappd or Vivino, which read as sketchy. The Untappd search key was also pinned in source, so a rotation would silently take beer and cider ratings down.

The keys themselves were never the risk: Algolia reports the Untappd key's ACL as `["search"]`, it has been public in Untappd's own search page since 2017, and we send it one product name with no cookies. The problem was purely that users had to approve hostnames they cannot identify.

## What changed

**Chrome declares no Algolia host at all.** Algolia is a browser-side search product and serves any origin, so the content script queries both indexes as ordinary CORS requests from the page — which requires no permission. The prompt now lists only systembolaget.se, vivino.com and untappd.com.

**Firefox cannot do this, so it keeps one permission.** Firefox routes content-script requests through the extension's own principal and blocks any host missing from `permissions`, regardless of what CORS allows. Confirmed rather than assumed: the identical fetch fails on `example.com` — a page with no CSP — while the same request from that page's main world returns 200. That build hands both lookups to the background.

**Untappd credentials are read at runtime.** The background parses `UNTAPPD_SEARCH_CONFIG` out of `untappd.com/search` (a host we already declare and users recognise) and caches the pair for a week, falling back to the pinned values only if that read fails. Because the app id determines the search hostname, an Algolia app migration heals itself too.

**Label thumbnails stay a background job.** `images.vivino.com` sends no CORS headers and the page CSP blocks hotlinking it, so `fetchRatingFromVivino` takes an injected image fetcher: the background calls it directly, the content script routes it through a `vivinoImage` message.

**Failures degrade honestly.** A rejected key or network error returns Uncertain with a working Untappd search link, marked transient so it is never cached — previously a silent `NotFound`, which rendered as "no rating exists".

## Verification

Both builds loaded as real extensions against live product pages:

| build | manifest | wine | beer |
| --- | --- | --- | --- |
| `chrome-mv3` | no algolia entry | `4 / 5 · 97163 votes` + 37 kB data-URL thumbnail | `2.86 / 5 · 416428 votes · Pabst Brewing Company` |
| `firefox-mv2` | `https://*.algolia.net/*` | `4 / 5 · 97163 votes` + thumbnail | `2.86 / 5 · 416428 votes · Pabst Brewing Company` |

On Chrome both Algolia hosts are reached from the content script with zero failed requests and no CSP violations. 29 API tests and 6 end-to-end tests pass; `compile`, `lint` and `ft:check` clean. The API spec now reads the live Untappd credentials, so a markup change there fails the test instead of quietly falling back to the pinned pair.

## Worth a second opinion

The Firefox permission is `https://*.algolia.net/*` rather than the two exact hosts. Since the Untappd app id is discovered at runtime and determines its hostname, the wildcard means an app migration needs no release — but it grants broader access, and Firefox words the prompt as "sites in the algolia.net domain". Easy to pin back if you would rather keep the scope minimal.

Firefox users still see the hostname at install. Moving it to `optional_permissions`, requested from the popup when someone switches a category on, would take it off that prompt as well — left out here since it changes the toggle semantics (all default to on today).
