### PR TITLE
chore: bump version from 1.3.1 to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bolaget-plus",
   "description": "Bolaget+ is a browser extension that adds more features to Systembolaget's website.",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.4.0",
   "type": "module",
   "author": "BroadcastDivers",
   "scripts": {


### PR DESCRIPTION
Cuts release **v1.4.0**. Merging this triggers `deploy.yaml`, which builds, submits to the Chrome Web Store and AMO, and publishes a GitHub release.

Contents since v1.3.1 (`f802684..HEAD`):

- `26bdee7` feat: zoom label thumbnails on hover (desktop)
- `32c65af` fix: correct zoom preview clamping and hide stale previews
- `2c3483f` fix: no more algolia.net host permission on Chrome; Untappd credentials read at runtime — #121

Minor rather than patch because of the hover-zoom feature.

**Permission change to be aware of when the stores review it.** Chrome loses two host permissions (`9wbo4rq3ho-dsn.algolia.net`, `9takgwjuxl-dsn.algolia.net`) and gains none — a strict reduction, so no user re-approval. Firefox swaps those two exact hosts for `https://*.algolia.net/*`, which is broader; existing Firefox users will likely be prompted to accept the updated permission on upgrade.

_(An earlier revision of this description credited the hover-zoom work to #119. That was wrong — #119 is an unrelated repo-health PR and is not part of this release.)_
