### PR TITLE
chore: bump version from 1.4.0 to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bolaget-plus",
   "description": "Bolaget+ is a browser extension that adds more features to Systembolaget's website.",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "module",
   "author": "BroadcastDivers",
   "scripts": {


### PR DESCRIPTION
Cuts release **v1.5.0**. Merging triggers `deploy.yaml`, which builds, submits to the Chrome Web Store and AMO, and publishes a GitHub release.

Contents since v1.4.0 — the repository-health pass from #119:

**User-visible fixes**
- Cached list-page ratings render immediately instead of trickling in one badge per 300 ms tick.
- Expired cache entries (including base64 label thumbnails) are swept on background startup, throttled to hourly, so `storage.local` no longer grows without bound. Torn cache writes are collected too.
- Removed the update-check button in the popup: it fetched `api.github.com`, which the extension CSP never allowed, so it was permanently disabled. The version label now reads from the manifest.

**Tooling**
- New vitest unit suite (`pnpm test:unit`, 27 tests, no network), now run in PR CI.
- `lint` and `ft` cover `e2e/` and the root configs rather than `src/` alone, with the errors that surfaced fixed.
- Docs refreshed to match the current architecture.

No manifest or permission changes in this release — the permission surface is unchanged from v1.4.0.
