### PR TITLE
chore: bump version from 1.5.0 to 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bolaget-plus",
   "description": "Bolaget+ is a browser extension that adds more features to Systembolaget's website.",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "author": "BroadcastDivers",
   "scripts": {


### PR DESCRIPTION
Re-releases 1.5.0's code as 1.5.1 so it can reach the Chrome Web Store.

## Why

1.5.0 shipped to the Firefox Addon Store but never reached Chrome. The deploy run ([30667548840](https://github.com/BroadcastDivers/bolaget-plus/actions/runs/30667548840)) rejected the Chrome upload:

```
ITEM_NOT_UPDATABLE: The item cannot be updated now because it is in
pending review, ready to publish, or deleted status.
```

The 1.4.0 bump was pushed 19 minutes before the 1.5.0 bump, and the Chrome Web Store refuses a new upload while an item is still in review. Firefox went through in the same run (0 errors, 5 warnings), so AMO is on 1.5.0 while Chrome is still on 1.4.0.

Re-running the failed workflow can't resolve this: it would re-submit 1.5.0, which AMO rejects as a duplicate version. A version bump is the only path that both stores accept.

1.4.0 has since cleared Chrome review, so the upload that failed before should now succeed.

## Changes

- `package.json`: `1.5.0` → `1.5.1`

WXT derives the manifest version from `package.json`, so no other file references the version. No functional changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoTs1SVc2V8TnfvoWqi6RQ)_