### PR TITLE
ci: badge deterministic CI, move live-site tests to a nightly smoke run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,13 @@
-name: PR Validation
+name: CI
 
+# Everything here is deterministic: no live Systembolaget, Vivino or Untappd
+# calls, so a red run means this repository is broken. That is what makes it
+# safe to put on the README badge. The tests that do hit those sites run in
+# playwright.yml on a nightly schedule.
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -9,6 +16,7 @@ permissions:
   contents: read
 
 jobs:
+  # Keep this job id stable — branch protection matches required checks on it.
   validate:
     runs-on: ubuntu-latest
     steps:
@@ -21,19 +29,23 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
       - run: pnpm install
-      
+
       - name: Check types
         run: pnpm compile
-        
+
       - name: Check formatting
         run: pnpm ft:check
-        
+
       - name: Lint code
         run: pnpm lint
 
       - name: Unit tests
         run: pnpm test:unit
 
+      # Mocked-fetch API regression tests. They never use the browser fixture,
+      # so Playwright needs no browser download here.
+      - name: API matching tests
+        run: pnpm test:matching
+
       - name: Build project
         run: pnpm build:chrome
- 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,11 +1,19 @@
-name: Playwright Tests
+name: Nightly Smoke Tests
+
+# Drives the live Systembolaget site and queries Vivino/Untappd for real. It
+# fails when those sites change their markup, rate-limit the runner, or are
+# simply down — which is worth knowing about, but says nothing about whether
+# this repository is healthy. So it is deliberately kept off the README badge
+# and off the PR path; CI (ci.yaml) is the build status. Run it by hand from
+# the Actions tab after touching selectors or the matching rules.
+#
+# Note: GitHub disables any workflow with a `schedule:` trigger after 60 days
+# without repository activity. If this stops running, re-enable it in the
+# Actions tab.
 on:
   schedule:
     - cron: '0 1 * * *'
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 permissions:
   contents: read
 jobs:
@@ -29,9 +37,11 @@ jobs:
         run: pnpm playwright install --with-deps
       - name: Build the project
         run: pnpm build:chrome
-      - name: Run Playwright tests
+      # The extension is loaded into a headed Chromium (extensions do not load
+      # in headless mode), hence xvfb.
+      - name: Run smoke tests
         run: |
-          xvfb-run pnpm playwright test
+          xvfb-run pnpm playwright test --project=smoke --project=live-api
         shell: bash
       - uses: actions/upload-artifact@v4
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,19 +29,27 @@ pnpm build:chrome      # build to .output/ (build:firefox for MV2/Firefox)
 pnpm zip:chrome        # package for store submission
 
 pnpm test:unit         # vitest unit tests (src/**/*.test.ts) — fast, no network
-pnpm test              # build:chrome then run full Playwright suite
+pnpm test:matching     # mocked-fetch matching regressions — fast, no network
+pnpm test:smoke        # build:chrome then the live-site + live-API projects
+pnpm test:live         # only the live Vivino/Untappd API spec
+pnpm test              # build:chrome then run every Playwright project
 pnpm test:interactive  # playwright --ui
-pnpm test:api          # only the Vivino/Untappd API-integration spec
 ```
 
 Run a single Playwright test: `pnpm build:chrome && playwright test -g "beer page"`
 (the build step is required — Playwright loads the built extension from
 `.output/`).
 
-CI (`.github/workflows/pr.yaml`) runs `compile`, `ft:check`, `lint`,
-`test:unit`, and `build:chrome` on every PR. The `pre-push` git hook
-(simple-git-hooks) runs `ft` + `lint` — installed automatically on
-`pnpm install`.
+CI (`.github/workflows/ci.yaml`) runs `compile`, `ft:check`, `lint`,
+`test:unit`, `test:matching`, and `build:chrome` on every PR and on push to
+`main`; it is the workflow the README badge reports, and everything in it is
+deterministic. The live-site tests run separately in
+`.github/workflows/playwright.yml` on a nightly cron — keep them out of CI, and
+keep them off the badge, so third-party markup changes don't read as a broken
+build. (That workflow's `schedule:` trigger also means GitHub disables it after
+60 days of repository inactivity; it then has to be re-enabled by hand in the
+Actions tab.) The `pre-push` git hook (simple-git-hooks) runs `ft` + `lint` —
+installed automatically on `pnpm install`.
 
 ## Architecture
 
@@ -123,11 +131,21 @@ the matching logic in `api.ts` against fixture Algolia responses and the cache
 against `fakeBrowser` storage — run them with `pnpm test:unit`; they need no
 network and are the first thing to extend when touching matching rules.
 
-Playwright tests in `e2e/` load the built extension. `end-to-end.spec.ts`
-runs against the **live** Systembolaget site, so it depends on that page's
-current markup and can be flaky — CI retries twice and runs serially; the
-tests must dismiss Systembolaget's age gate ("Jag har fyllt 20 år") and cookie
-banner ("Acceptera alla kakor") before asserting on `#rating-container`.
-`api-integration.spec.ts` mixes a few live Vivino/Untappd queries with
-mocked-`fetch` regression tests for the matching rules. `fixtures.ts`
-provides the `extensionId` fixture.
+The Playwright tests in `e2e/` are split into three projects
+(`playwright.config.ts`), divided by whether they touch the network:
+
+- `matching` (`api-matching.spec.ts`) — mocked-`fetch` regression tests for the
+  matching rules. No network, no browser, ~2 s. Runs in CI.
+- `smoke` (`end-to-end.spec.ts`) — loads the built extension into a headed
+  Chromium and drives the **live** Systembolaget site, so it depends on that
+  page's current markup and can be flaky (retries twice and runs serially on
+  CI). `fixtures.ts` provides the `extensionId` fixture; `systembolaget.ts`
+  provides `openPage`, which dismisses the age gate ("Jag har fyllt 20 år") and
+  cookie banner ("Acceptera alla kakor") tolerantly — a gate that never appears
+  is not an error, so a banner change fails no test on its own.
+- `live-api` (`api-live.spec.ts`) — real queries against Vivino and Untappd,
+  including reading Untappd's search credentials out of its live markup.
+
+Only `matching` belongs in CI. When adding a Playwright test, decide which
+project it lands in first: if it needs a third party to be up, it is a smoke
+test.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bolaget+
 
-[![GitHub Release](https://img.shields.io/github/release/BroadcastDivers/bolaget-plus.svg?style=flat)]() [![Playwright Tests](https://github.com/BroadcastDivers/bolaget-plus/actions/workflows/playwright.yml/badge.svg)](https://github.com/BroadcastDivers/bolaget-plus/actions/workflows/playwright.yml)
+[![GitHub Release](https://img.shields.io/github/release/BroadcastDivers/bolaget-plus.svg?style=flat)]() [![CI](https://github.com/BroadcastDivers/bolaget-plus/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/BroadcastDivers/bolaget-plus/actions/workflows/ci.yaml)
 
 A browser plugin for Systembolaget.se that shows ratings directly at systembolagets website!
 
@@ -52,16 +52,20 @@ pnpm dev:chrome
 
 ### Testing
 
-Run the unit tests (fast, no network):
+Run the checks CI gates on (fast, no network):
 
 ```sh
-pnpm test:unit
+pnpm test:unit       # vitest unit tests
+pnpm test:matching   # mocked-fetch Vivino/Untappd matching regressions
 ```
 
-Run the end-to-end tests (builds the extension, then drives it against the live sites with Playwright):
+Run the smoke tests (builds the extension, then drives it against the live
+Systembolaget/Vivino/Untappd sites with Playwright). These depend on those
+sites' current markup and availability, so they are expected to be flaky and
+run nightly rather than on every push:
 
 ```sh
-pnpm test
+pnpm test:smoke
 ```
 
 ### Building

--- a/e2e/api-live.spec.ts
+++ b/e2e/api-live.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test'
+
+import { RatingResultStatus, UntappdSearchConfig } from '../src/@types/types'
+import {
+  fetchRatingFromUntappd,
+  fetchRatingFromVivino,
+  fetchUntappdSearchConfig
+} from '../src/components/api'
+
+// These tests query Vivino and Untappd for real, so they fail whenever those
+// sites change, rate-limit the runner, or are simply down. That is the point —
+// but it also means they are not a signal about this repository, so they live
+// in the nightly smoke run rather than in CI. The mocked counterparts that do
+// gate CI are in api-matching.spec.ts.
+
+// The credentials Untappd's search page is shipping right now. Reading them
+// live is the point: if their markup changes, these tests fail instead of the
+// extension silently falling back to a pinned key that may be rotated out.
+const liveConfig: UntappdSearchConfig = {
+  appId: '9WBO4RQ3HO',
+  searchKey: '1d347324d67ec472bb7132c66aead485'
+}
+
+test.describe('API Integration Tests', () => {
+  test('fetchUntappdSearchConfig reads live credentials from untappd.com', async () => {
+    const config = await fetchUntappdSearchConfig()
+
+    expect(config.appId).toMatch(/^[0-9A-Z]{10}$/)
+    expect(config.searchKey).toMatch(/^[0-9a-f]{32}$/)
+    // Copy them onto the shared object so the lookups below use whatever is
+    // live, not a hardcoded pair.
+    Object.assign(liveConfig, config)
+  })
+
+  test('fetchRatingFromVivino returns data for valid query', async () => {
+    const result = await fetchRatingFromVivino('Bread & Butter')
+
+    expect(result).not.toBeNull()
+    expect(result.status).toBe(RatingResultStatus.Found)
+    expect(result.rating).toBeGreaterThan(0)
+    expect(result.votes).toBeGreaterThan(0)
+    expect(result.link).toContain('vivino.com')
+  })
+
+  // Regression: the explore endpoint missed even top-selling wines (its index
+  // only covers marketplace listings). The Algolia index must find them.
+  test('fetchRatingFromVivino finds a top-selling wine', async () => {
+    const result = await fetchRatingFromVivino(
+      'Casillero del Diablo Cabernet Sauvignon',
+      false
+    )
+
+    expect(result.status).toBe(RatingResultStatus.Found)
+    expect(result.votes).toBeGreaterThan(10000)
+  })
+
+  test('fetchRatingFromUntappd returns data for valid query', async () => {
+    const result = await fetchRatingFromUntappd('Pabst Blue Ribbon', liveConfig)
+
+    expect(result).not.toBeNull()
+    expect(result.status).toBe(RatingResultStatus.Found)
+    expect(result.rating).toBeGreaterThan(0)
+    expect(result.votes).toBeGreaterThan(0)
+    expect(result.link).toContain('untappd.com')
+  })
+
+  test('fetchRatingFromUntappd returns data for a cider query', async () => {
+    const result = await fetchRatingFromUntappd('Rekorderlig Päron', liveConfig)
+
+    expect(result).not.toBeNull()
+    expect(result.status).toBe(RatingResultStatus.Found)
+    expect(result.rating).toBeGreaterThan(0)
+    expect(result.votes).toBeGreaterThan(0)
+    expect(result.link).toContain('untappd.com')
+  })
+})

--- a/e2e/api-matching.spec.ts
+++ b/e2e/api-matching.spec.ts
@@ -5,71 +5,20 @@ import type { VivinoHit } from '../src/@types/types'
 import { RatingResultStatus, UntappdSearchConfig } from '../src/@types/types'
 import {
   fetchRatingFromUntappd,
-  fetchRatingFromVivino,
-  fetchUntappdSearchConfig
+  fetchRatingFromVivino
 } from '../src/components/api'
 
-// The credentials Untappd's search page is shipping right now. Reading them
-// live is the point: if their markup changes, these tests fail instead of the
-// extension silently falling back to a pinned key that may be rotated out.
-const liveConfig: UntappdSearchConfig = {
+// Every test in this file stubs globalThis.fetch, so it needs no network and
+// no browser: these are the API regression tests that gate CI. The live
+// Vivino/Untappd queries they were extracted from are in api-live.spec.ts.
+
+// The search credentials the mocked Untappd responses are answered with. The
+// live values are read from untappd.com by api-live.spec.ts; here they only
+// need to be well-formed.
+const searchConfig: UntappdSearchConfig = {
   appId: '9WBO4RQ3HO',
   searchKey: '1d347324d67ec472bb7132c66aead485'
 }
-
-test.describe('API Integration Tests', () => {
-  test('fetchUntappdSearchConfig reads live credentials from untappd.com', async () => {
-    const config = await fetchUntappdSearchConfig()
-
-    expect(config.appId).toMatch(/^[0-9A-Z]{10}$/)
-    expect(config.searchKey).toMatch(/^[0-9a-f]{32}$/)
-    // Copy them onto the shared object so the lookups below use whatever is
-    // live, not a hardcoded pair.
-    Object.assign(liveConfig, config)
-  })
-
-  test('fetchRatingFromVivino returns data for valid query', async () => {
-    const result = await fetchRatingFromVivino('Bread & Butter')
-
-    expect(result).not.toBeNull()
-    expect(result.status).toBe(RatingResultStatus.Found)
-    expect(result.rating).toBeGreaterThan(0)
-    expect(result.votes).toBeGreaterThan(0)
-    expect(result.link).toContain('vivino.com')
-  })
-
-  // Regression: the explore endpoint missed even top-selling wines (its index
-  // only covers marketplace listings). The Algolia index must find them.
-  test('fetchRatingFromVivino finds a top-selling wine', async () => {
-    const result = await fetchRatingFromVivino(
-      'Casillero del Diablo Cabernet Sauvignon',
-      false
-    )
-
-    expect(result.status).toBe(RatingResultStatus.Found)
-    expect(result.votes).toBeGreaterThan(10000)
-  })
-
-  test('fetchRatingFromUntappd returns data for valid query', async () => {
-    const result = await fetchRatingFromUntappd('Pabst Blue Ribbon', liveConfig)
-
-    expect(result).not.toBeNull()
-    expect(result.status).toBe(RatingResultStatus.Found)
-    expect(result.rating).toBeGreaterThan(0)
-    expect(result.votes).toBeGreaterThan(0)
-    expect(result.link).toContain('untappd.com')
-  })
-
-  test('fetchRatingFromUntappd returns data for a cider query', async () => {
-    const result = await fetchRatingFromUntappd('Rekorderlig Päron', liveConfig)
-
-    expect(result).not.toBeNull()
-    expect(result.status).toBe(RatingResultStatus.Found)
-    expect(result.rating).toBeGreaterThan(0)
-    expect(result.votes).toBeGreaterThan(0)
-    expect(result.link).toContain('untappd.com')
-  })
-})
 
 // Routes mocked fetches: true for the Algolia search call, false for the
 // image downloads that follow it.
@@ -687,7 +636,10 @@ test.describe('Untappd lookup misses (mocked fetch)', () => {
         ok: true
       } as Response)
 
-    const result = await fetchRatingFromUntappd('Mystery Brew IPA', liveConfig)
+    const result = await fetchRatingFromUntappd(
+      'Mystery Brew IPA',
+      searchConfig
+    )
 
     expect(result.status).toBe(RatingResultStatus.Uncertain)
     expect(result.link).toContain('untappd.com/search')

--- a/e2e/end-to-end.spec.ts
+++ b/e2e/end-to-end.spec.ts
@@ -1,4 +1,8 @@
 import { expect, test } from './fixtures'
+import { openPage, RATING_TIMEOUT } from './systembolaget'
+
+// These tests drive the live Systembolaget site, so they break when it changes.
+// They run in the nightly smoke workflow, not in CI — see playwright.config.ts.
 
 test('visiting wine page shows rating-container', async ({
   extensionId,
@@ -11,11 +15,11 @@ test('visiting wine page shows rating-container', async ({
   await expect(page.locator('#wine')).toBeChecked()
 
   // act
-  await page.goto('https://www.systembolaget.se/produkt/vin/amadio-203701/')
-  await page.getByRole('link', { name: 'Jag har fyllt 20 år' }).click()
-  await page.getByRole('button', { name: 'Acceptera alla kakor' }).click()
-  await page.reload()
-  await page.waitForSelector('#rating-container')
+  await openPage(
+    page,
+    'https://www.systembolaget.se/produkt/vin/amadio-203701/'
+  )
+  await page.waitForSelector('#rating-container', { timeout: RATING_TIMEOUT })
 
   // assert
   await expect(page.locator('#rating-container')).toBeVisible()
@@ -32,14 +36,14 @@ test('visiting beer page shows rating-container with votes', async ({
   await expect(page.locator('#beer')).toBeChecked()
 
   // act
-  await page.goto('https://www.systembolaget.se/produkt/ol/pabst-155315/')
-  await page.getByRole('link', { name: 'Jag har fyllt 20 år' }).click()
-  await page.getByRole('button', { name: 'Acceptera alla kakor' }).click()
-  await page.reload()
-  await page.locator('#rating-container').waitFor()
+  await openPage(page, 'https://www.systembolaget.se/produkt/ol/pabst-155315/')
+  await page.locator('#rating-container').waitFor({ timeout: RATING_TIMEOUT })
 
   // Wait for the spinner to be removed
-  await page.waitForSelector('.bp-spinner', { state: 'detached' })
+  await page.waitForSelector('.bp-spinner', {
+    state: 'detached',
+    timeout: RATING_TIMEOUT
+  })
   await page.waitForSelector('#rating-container-body')
   // assert
   const res = await page.locator('#rating-container').textContent()
@@ -57,16 +61,17 @@ test('visiting cider page shows rating-container with votes', async ({
   await expect(page.locator('#cider')).toBeChecked()
 
   // act
-  await page.goto(
+  await openPage(
+    page,
     'https://www.systembolaget.se/produkt/cider-blanddrycker/somersby-182435/'
   )
-  await page.getByRole('link', { name: 'Jag har fyllt 20 år' }).click()
-  await page.getByRole('button', { name: 'Acceptera alla kakor' }).click()
-  await page.reload()
-  await page.locator('#rating-container').waitFor()
+  await page.locator('#rating-container').waitFor({ timeout: RATING_TIMEOUT })
 
   // Wait for the spinner to be removed
-  await page.waitForSelector('.bp-spinner', { state: 'detached' })
+  await page.waitForSelector('.bp-spinner', {
+    state: 'detached',
+    timeout: RATING_TIMEOUT
+  })
   await page.waitForSelector('#rating-container-body')
   // assert
   const res = await page.locator('#rating-container').textContent()
@@ -87,10 +92,10 @@ test('visiting a wine page with wine toggle disabled should not show wine', asyn
   await expect(page.locator('#wine')).not.toBeChecked()
 
   // act
-  await page.goto('https://www.systembolaget.se/produkt/vin/amadio-203701/')
-  await page.getByRole('link', { name: 'Jag har fyllt 20 år' }).click()
-  await page.getByRole('button', { name: 'Acceptera alla kakor' }).click()
-  await page.reload()
+  await openPage(
+    page,
+    'https://www.systembolaget.se/produkt/vin/amadio-203701/'
+  )
 
   // assert
   await expect(page.locator('#rating-container')).not.toBeVisible()
@@ -107,17 +112,20 @@ test('visiting a wine page shows rating-container with ratings and stars', async
   await expect(page.locator('#wine')).toBeChecked()
 
   // act
-  await page.goto(
+  await openPage(
+    page,
     'https://www.systembolaget.se/produkt/vin/bread-butter-7667101/'
   )
-  await page.getByRole('link', { name: 'Jag har fyllt 20 år' }).click()
-  await page.getByRole('button', { name: 'Acceptera alla kakor' }).click()
-  await page.reload()
 
   // Wait for the spinner to be removed
-  await page.waitForSelector('.bp-spinner', { state: 'detached' })
+  await page.waitForSelector('.bp-spinner', {
+    state: 'detached',
+    timeout: RATING_TIMEOUT
+  })
 
-  await page.waitForSelector('#rating-container-body')
+  await page.waitForSelector('#rating-container-body', {
+    timeout: RATING_TIMEOUT
+  })
 
   // assert
   const ratingContainer = page.locator('#rating-container-body')
@@ -144,11 +152,8 @@ test('visiting wine list page shows rating badges on product cards', async ({
   await expect(page.locator('#enabled')).toBeChecked()
   await expect(page.locator('#wine')).toBeChecked()
 
-  await page.goto('https://www.systembolaget.se/sortiment/vin/')
-  await page.getByRole('link', { name: 'Jag har fyllt 20 år' }).click()
-  await page.getByRole('button', { name: 'Acceptera alla kakor' }).click()
-  await page.reload()
+  await openPage(page, 'https://www.systembolaget.se/sortiment/vin/')
 
-  await page.waitForSelector('.bp-card-rating', { timeout: 20000 })
+  await page.waitForSelector('.bp-card-rating', { timeout: RATING_TIMEOUT })
   await expect(page.locator('.bp-card-rating').first()).toBeVisible()
 })

--- a/e2e/systembolaget.ts
+++ b/e2e/systembolaget.ts
@@ -1,0 +1,62 @@
+import type { Locator, Page } from '@playwright/test'
+
+// How long to wait for a gate to show up on a freshly loaded page. Generous,
+// because these tests hit the live site over whatever the runner's network
+// happens to be.
+const GATE_TIMEOUT = 10_000
+
+// How long a rating may take to appear. The content script has to round-trip
+// through the background script to Vivino/Untappd before it can render.
+export const RATING_TIMEOUT = 30_000
+
+/**
+ * Clicks away the age gate and the cookie banner.
+ *
+ * Neither is guaranteed to be there: the profile may already have consented,
+ * the site A/B-tests the banner, and the markup has changed before. So a gate
+ * that never shows up is not an error — the previous version of these tests
+ * clicked both unconditionally, which turned any change to either interstitial
+ * into six failures that pointed at the banner instead of at the assertion the
+ * test actually cares about.
+ */
+export async function dismissGates(page: Page): Promise<void> {
+  const gates: Locator[] = [
+    page.getByRole('link', { name: 'Jag har fyllt 20 år' }).first(),
+    page.getByRole('button', { name: 'Acceptera alla kakor' }).first()
+  ]
+
+  // Dismissing one gate can reveal the other, so make a second pass — but only
+  // if the first pass actually cleared something, and with a short timeout,
+  // since by then anything still coming has already had GATE_TIMEOUT to render.
+  for (let pass = 0; pass < gates.length; pass++) {
+    let dismissedAny = false
+
+    for (const gate of gates) {
+      try {
+        await gate.waitFor({
+          state: 'visible',
+          timeout: pass === 0 ? GATE_TIMEOUT : 1_000
+        })
+      } catch {
+        continue // Not on this page (or no longer) — nothing to dismiss.
+      }
+      await gate.click()
+      dismissedAny = true
+    }
+
+    if (!dismissedAny) break
+  }
+}
+
+/**
+ * Opens a Systembolaget page with the interstitials cleared.
+ *
+ * The reload is what makes the ratings show up: the content script runs against
+ * whatever the gates were covering, so it needs one clean pass over the real
+ * page after they are gone.
+ */
+export async function openPage(page: Page, url: string): Promise<void> {
+  await page.goto(url)
+  await dismissGates(page)
+  await page.reload()
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "lint:fix": "eslint . --fix",
     "test": "pnpm build:chrome && playwright test",
     "test:interactive": "playwright test --ui",
-    "test:api": "pnpm build:chrome && playwright test e2e/api-integration.spec.ts",
+    "test:matching": "playwright test --project=matching",
+    "test:smoke": "pnpm build:chrome && playwright test --project=smoke --project=live-api",
+    "test:live": "playwright test --project=live-api",
     "test:unit": "vitest run"
   },
   "devDependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,19 +1,32 @@
 import { defineConfig, devices } from '@playwright/test'
 
+// Two classes of test live in e2e/, and they are kept in separate projects
+// because only one of them says anything about this repository:
+//
+//   matching            mocked fetch, no network, no browser. Deterministic,
+//                       so CI gates on it and the README badge reports it.
+//   smoke / live-api    drive the live Systembolaget site and query
+//                       Vivino/Untappd for real. Run nightly; they fail when
+//                       those sites change or are down, which is worth an
+//                       alert but is not a build status.
 export default defineConfig({
   // Fail the build on CI if you accidentally left test.only in the source code.
   forbidOnly: !!process.env.CI,
   // Configure projects for major browsers.
   projects: [
     {
-      name: 'chromium',
-      testIgnore: /api-integration\.spec\.ts/, // Exclude API tests from the chromium project
-      testMatch: /.*\.spec\.ts/,
+      name: 'matching',
+      testMatch: /api-matching\.spec\.ts/,
+      use: {}
+    },
+    {
+      name: 'smoke',
+      testMatch: /end-to-end\.spec\.ts/,
       use: { ...devices['Desktop Chrome'] }
     },
     {
-      name: 'api',
-      testMatch: /api-integration\.spec\.ts/,
+      name: 'live-api',
+      testMatch: /api-live\.spec\.ts/,
       use: {}
     }
   ],


### PR DESCRIPTION
Fixes the failing Playwright badge in the README.

## The badge is red for two unrelated reasons

**1. The workflow has not run since 2025-09-13.** It is in state `disabled_inactivity` — GitHub auto-disables any workflow with a `schedule:` trigger after 60 days of repository inactivity, and that kills *all* of its triggers, not just the cron. Every commit on `main` since then (including the 1.4.0/1.5.0/1.5.1 bumps) silently skipped it. The badge has been frozen on an 11-month-old failed run.

**2. The badge pointed at the one workflow we do not control.** Of the tests in `playwright.yml`, 11 depend on third-party markup and uptime: six drive the live Systembolaget site, five query Vivino/Untappd for real (including scraping Untappd's search credentials out of its HTML). It goes red when Systembolaget reskins a banner or a runner gets rate-limited — which reads as "the extension is broken" when nothing here changed. Meanwhile `compile`, `ft:check`, `lint`, `test:unit` and `build:chrome` ran only on `pull_request` and were on no badge at all.

## Changes

Split the Playwright suite into three projects by whether they touch the network:

| project | file | network | runs in |
| --- | --- | --- | --- |
| `matching` | `api-matching.spec.ts` (24 tests) | none | **CI — the badge** |
| `smoke` | `end-to-end.spec.ts` (6 tests) | live Systembolaget | nightly |
| `live-api` | `api-live.spec.ts` (5 tests) | live Vivino/Untappd | nightly |

The 24 mocked-`fetch` matching regressions already existed inside `api-integration.spec.ts` — that file was ~5 live tests bolted onto ~24 offline ones, so this is mostly a cut at the existing seam. All 35 tests are still routed to a project; none were dropped or skipped.

- `pr.yaml` → `ci.yaml`, now also triggered on push to `main` so the badge tracks `main`. The job id stays `validate` so any required status check still matches. Adds a `test:matching` step.
- `playwright.yml` → "Nightly Smoke Tests": keeps only the cron, gains `workflow_dispatch`, runs the two live projects.
- README badge repointed at `ci.yaml` with `?branch=main&event=push`.
- New scripts: `test:matching`, `test:smoke`, `test:live` (replacing `test:api`).

### Smoke-test hardening

All six live tests clicked the age gate and cookie banner unconditionally:

```ts
await page.getByRole('link', { name: 'Jag har fyllt 20 år' }).click()
await page.getByRole('button', { name: 'Acceptera alla kakor' }).click()
```

So any change to either interstitial failed all six tests *at the banner*, never reaching the assertion under test. They now share `openPage()` from the new `e2e/systembolaget.ts`, which dismisses whichever gates are actually present, treats an absent gate as fine rather than an error, and makes a second pass since clearing one can reveal the other.

## Verification

Ran the full CI gate locally — `compile`, `ft:check`, `lint`, 27 unit tests, 24 matching tests, `build:chrome` — all green. Also confirmed the matching project passes with `PLAYWRIGHT_BROWSERS_PATH` pointed at an empty directory, so CI needs no `playwright install` step (~1 min saved per run).

## Two caveats

**The nightly workflow still has to be re-enabled by hand** — Actions → Nightly Smoke Tests → *Enable workflow*. Nothing in this PR can do that; a disabled workflow stays disabled until a human enables it. The new `ci.yaml` is a fresh workflow file, so it is enabled from its first run and unaffected. The nightly will be auto-disabled again if the repo goes quiet for another 60 days — inherent to `schedule:`, and now documented in the workflow and CLAUDE.md.

**The original September failure was never reproduced.** Logs for all three failing runs return `410 Gone` (90-day retention), so the specific broken assertion is unknown. The gate hardening addresses the most likely cause, but that is reasoning from the code, not a repro. The first nightly run after re-enabling is what will confirm it — if something else drifted in the last 11 months (a changed product URL, a renamed CSS class), it will surface there, and now it will surface without turning the README red.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJFW7UCywCzTDraWeF8d4q)_