### PR TITLE
fix: skip non-bottle wines on list-page cards too

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,9 @@ external fetches are delegated to the background script.
    `/produkt/ol/`, `/produkt/cider-blanddrycker/`), extracts the product name
    from the `<h1>` (or from a card's text lines), and gates wine on
    `isBottle()` (Vivino only rates bottles, not box/bag-in-box/etc. — see the
-   exclusion-list note in that file).
+   exclusion-list note in that file). `isCardBottle()` applies the same gate to
+   list cards, reading the packaging from the `__NEXT_DATA__` payload when the
+   card's product is in it and falling back to the card's own detail lines.
 3. `ratingService.fetchRating` checks the local cache first
    (`ratingsCache.ts`), otherwise sends a `RatingRequest` message to the
    background script and caches responses that are neither `NotFound` nor
@@ -127,9 +129,12 @@ hardcoded strings.
 ## Testing notes
 
 Unit tests (`src/**/*.test.ts`, vitest with WXT's `WxtVitest` plugin) cover
-the matching logic in `api.ts` against fixture Algolia responses and the cache
-against `fakeBrowser` storage — run them with `pnpm test:unit`; they need no
-network and are the first thing to extend when touching matching rules.
+the matching logic in `api.ts` against fixture Algolia responses, the cache
+against `fakeBrowser` storage, and the list-card parsing in `productUtils.ts`
+against synthetic card markup — run them with `pnpm test:unit`; they need no
+network and are the first thing to extend when touching matching rules. Tests
+that need a DOM opt in per file with a `// @vitest-environment happy-dom`
+docblock; the default environment stays `node`.
 
 The Playwright tests in `e2e/` are split into three projects
 (`playwright.config.ts`), divided by whether they touch the network:

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@wxt-dev/auto-icons": "^1.1.2",
     "eslint": "^9.39.4",
     "eslint-plugin-perfectionist": "^4.15.1",
+    "happy-dom": "^20.11.1",
     "playwright": "^1.61.0",
     "prettier": "^3.8.4",
     "simple-git-hooks": "^2.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       eslint-plugin-perfectionist:
         specifier: ^4.15.1
         version: 4.15.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      happy-dom:
+        specifier: ^20.11.1
+        version: 20.11.1
       playwright:
         specifier: ^1.61.0
         version: 1.61.0
@@ -73,7 +76,7 @@ importers:
         version: 8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0))
+        version: 4.1.10(@types/node@25.9.3)(happy-dom@20.11.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0))
       webextension-polyfill:
         specifier: ^0.12.0
         version: 0.12.0
@@ -1010,6 +1013,12 @@ packages:
   '@types/webextension-polyfill@0.12.5':
     resolution: {integrity: sha512-uKSAv6LgcVdINmxXMKBuVIcg/2m5JZugoZO8x20g7j2bXJkPIl/lVGQcDlbV+aXAiTyXT2RA5U5mI4IGCDMQeg==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/eslint-plugin@8.61.1':
     resolution: {integrity: sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1227,6 +1236,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -1695,6 +1708,10 @@ packages:
 
   growly@1.3.0:
     resolution: {integrity: sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==}
+
+  happy-dom@20.11.1:
+    resolution: {integrity: sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2787,6 +2804,10 @@ packages:
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   when-exit@2.1.5:
     resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
 
@@ -2829,6 +2850,18 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
@@ -3499,6 +3532,12 @@ snapshots:
 
   '@types/webextension-polyfill@0.12.5': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.3
+
   '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -3759,6 +3798,10 @@ snapshots:
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
+
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 25.9.3
 
   bundle-name@4.1.0:
     dependencies:
@@ -4244,6 +4287,19 @@ snapshots:
   graceful-readlink@1.0.1: {}
 
   growly@1.3.0: {}
+
+  happy-dom@20.11.1:
+    dependencies:
+      '@types/node': 25.9.3
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -5229,7 +5285,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
 
-  vitest@4.1.10(@types/node@25.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)):
+  vitest@4.1.10(@types/node@25.9.3)(happy-dom@20.11.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0))
@@ -5253,6 +5309,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.3
+      happy-dom: 20.11.1
     transitivePeerDependencies:
       - msw
 
@@ -5289,6 +5346,8 @@ snapshots:
   webextension-polyfill@0.12.0: {}
 
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   when-exit@2.1.5: {}
 
@@ -5333,6 +5392,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  ws@8.21.1: {}
 
   wsl-utils@0.3.1:
     dependencies:

--- a/src/components/productUtils.test.ts
+++ b/src/components/productUtils.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { getCardName, isCardBottle } from '@/components/productUtils'
+
+// A list card as Systembolaget renders it: category line, name, subtitle,
+// the "Nr {productNumber}" line, then the format/price details.
+function renderCard(options: {
+  category?: string
+  details?: string[]
+  productId?: string
+  subtitle?: string
+  title?: string
+}): Element {
+  const {
+    category = 'Rött vin, Fylligt & Smakrikt',
+    details = ['Flaska, 750 ml', '129:00', '172:00 kr/l'],
+    productId = '203701',
+    subtitle = '2021',
+    title = 'Amadio'
+  } = options
+
+  const lines = [category, title, subtitle, `Nr ${productId}`, ...details]
+  document.body.innerHTML = `
+    <a id="tile:${productId}" href="/produkt/vin/amadio-${productId}/">
+      ${lines.map((line) => `<p>${line}</p>`).join('')}
+    </a>`
+
+  const card = document.querySelector('a')
+  if (!card) throw new Error('card not rendered')
+  return card
+}
+
+function renderPageData(products: object[]): void {
+  const script = document.createElement('script')
+  script.id = '__NEXT_DATA__'
+  script.textContent = JSON.stringify({
+    props: { pageProps: { fallback: { '/api/search': { products } } } }
+  })
+  document.head.appendChild(script)
+}
+
+beforeEach(() => {
+  document.head.innerHTML = ''
+  document.body.innerHTML = ''
+})
+
+describe('isCardBottle', () => {
+  it('accepts a card whose details say nothing about the packaging', () => {
+    const card = renderCard({ details: ['750 ml', '129:00'] })
+
+    expect(isCardBottle(card, '203701')).toBe(true)
+  })
+
+  it('rejects a bag-in-box card', () => {
+    const card = renderCard({ details: ['Bag-in-Box, 3000 ml', '249:00'] })
+
+    expect(isCardBottle(card, '203701')).toBe(false)
+  })
+
+  it.each(['Box, 3000 ml', 'Burk, 250 ml', 'PET-flaska, 750 ml', 'Fat, 20 l'])(
+    'rejects a card packaged as %s',
+    (packaging) => {
+      const card = renderCard({ details: [packaging, '249:00'] })
+
+      expect(isCardBottle(card, '203701')).toBe(false)
+    }
+  )
+
+  it('ignores a format word that is part of the product name', () => {
+    const card = renderCard({ title: 'Boxwood Petit Verdot' })
+
+    expect(isCardBottle(card, '203701')).toBe(true)
+  })
+
+  it('ignores a format word that is only part of a longer word', () => {
+    const card = renderCard({ details: ['Flaska, 750 ml', 'Fatlagrat'] })
+
+    expect(isCardBottle(card, '203701')).toBe(true)
+  })
+
+  it('reads the packaging from the embedded page data when present', () => {
+    renderPageData([{ packagingLevel1: 'Box', productNumber: '203701' }])
+    // Details deliberately look like a bottle — the page data is authoritative.
+    const card = renderCard({ details: ['3000 ml', '249:00'] })
+
+    expect(isCardBottle(card, '203701')).toBe(false)
+  })
+
+  it('does not apply another product’s packaging to this card', () => {
+    renderPageData([{ packagingLevel1: 'Box', productNumber: '999999' }])
+    const card = renderCard({})
+
+    expect(isCardBottle(card, '203701')).toBe(true)
+  })
+
+  it('falls back to the card text when the page data is unparseable', () => {
+    const script = document.createElement('script')
+    script.id = '__NEXT_DATA__'
+    script.textContent = '{ not json'
+    document.head.appendChild(script)
+    const card = renderCard({ details: ['Box, 3000 ml'] })
+
+    expect(isCardBottle(card, '203701')).toBe(false)
+  })
+
+  it('assumes bottle when the product-number line is missing', () => {
+    const card = renderCard({ details: ['Box, 3000 ml'], productId: '203701' })
+    card.innerHTML = '<p>Amadio</p><p>Box, 3000 ml</p>'
+
+    expect(isCardBottle(card, '203701')).toBe(true)
+  })
+})
+
+describe('getCardName', () => {
+  it('joins the name and vintage above the product-number line', () => {
+    const card = renderCard({})
+
+    expect(getCardName(card)).toBe('Amadio 2021')
+  })
+
+  it('drops the category line', () => {
+    const card = renderCard({ subtitle: '' })
+
+    expect(getCardName(card)).toBe('Amadio')
+  })
+})

--- a/src/components/productUtils.ts
+++ b/src/components/productUtils.ts
@@ -14,12 +14,8 @@ export function getCardName(card: Element): null | string {
   // subtitle/vintage are the lines directly above it. Systembolaget's class
   // names are hashed build artifacts (monopol-*, css-*) and reshuffle
   // between deploys, so text structure is the only stable thing to hold on to.
-  const lines = (card as HTMLElement).innerText
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-  const nrPattern = new RegExp(`^Nr\\s*${productId}$`)
-  const nrIndex = lines.findIndex((line) => nrPattern.test(line))
+  const lines = getCardLines(card)
+  const nrIndex = findProductNumberLine(lines, productId)
   if (nrIndex <= 0) return null
 
   let titleLines = lines.slice(Math.max(0, nrIndex - 2), nrIndex)
@@ -107,6 +103,14 @@ const NON_BOTTLE_FORMATS = [
   'pouch'
 ]
 
+// A list card's text is free-form (volume, price, availability, …) rather than
+// a packaging descriptor, so the formats have to match as whole words here:
+// "Bag-in-Box" and "PET" must hit, "Petit" and "fatlagrat" must not.
+const NON_BOTTLE_PATTERN = new RegExp(
+  `(?<![\\p{L}\\p{N}])(?:${NON_BOTTLE_FORMATS.join('|')})(?![\\p{L}\\p{N}])`,
+  'iu'
+)
+
 export function isBottle(): boolean {
   const main = document.querySelector('main')
   if (main == null) {
@@ -123,15 +127,94 @@ export function isBottle(): boolean {
     return true
   }
 
-  return !NON_BOTTLE_FORMATS.some((format) => descriptor.includes(format))
+  return !isNonBottlePackaging(descriptor)
+}
+
+// The list-page counterpart of isBottle(): a card links straight to the product
+// page, so a box wine has to be filtered out here too or the badge shows a
+// rating the product page itself refuses to show.
+export function isCardBottle(card: Element, productId: string): boolean {
+  const packaging = getPackagingFromPageData(productId)
+  if (packaging) {
+    return !isNonBottlePackaging(packaging)
+  }
+
+  // Cards the embedded page data doesn't cover (later result pages, filters
+  // applied after load) only leave their own text. Scan the lines below the
+  // product number — the name and category above it are prose, and a wine
+  // called "Box Wine Co" is not a box.
+  const lines = getCardLines(card)
+  const nrIndex = findProductNumberLine(lines, productId)
+  if (nrIndex < 0) {
+    return true
+  }
+
+  return !NON_BOTTLE_PATTERN.test(lines.slice(nrIndex + 1).join(' '))
 }
 
 export function isListPage(): boolean {
   return window.location.pathname.includes('/sortiment/')
 }
 
+function buildPackagingMap(raw: string): Map<string, string> {
+  const map = new Map<string, string>()
+
+  let root: unknown
+  try {
+    const parsed = JSON.parse(raw) as {
+      props?: { pageProps?: { fallback?: unknown } }
+    }
+    root = parsed.props?.pageProps?.fallback
+  } catch {
+    return map
+  }
+
+  // The fallback is keyed by request URL and shaped differently per page type
+  // (a bare product, a search response, a paged list), so walk it and index
+  // every product object found rather than guessing at the nesting. The node
+  // budget keeps an unexpectedly large payload from stalling the page.
+  const queue: unknown[] = [root]
+  for (let visited = 0; queue.length > 0 && visited < 5000; visited++) {
+    const node = queue.shift()
+    if (typeof node !== 'object' || node === null) {
+      continue
+    }
+    if (Array.isArray(node)) {
+      queue.push(...(node as unknown[]))
+      continue
+    }
+
+    const product = node as {
+      packagingLevel1?: unknown
+      productNumber?: unknown
+    }
+    if (
+      typeof product.productNumber === 'string' &&
+      typeof product.packagingLevel1 === 'string' &&
+      product.packagingLevel1
+    ) {
+      map.set(product.productNumber, product.packagingLevel1.toLowerCase())
+    }
+    queue.push(...(Object.values(node) as unknown[]))
+  }
+
+  return map
+}
+
 function extractProductId(url: string): null | string {
   return /-(\d+)\/?$/.exec(url)?.[1] ?? null
+}
+
+function findProductNumberLine(lines: string[], productId: string): number {
+  const nrPattern = new RegExp(`^Nr\\s*${productId}$`)
+  return lines.findIndex((line) => nrPattern.test(line))
+}
+
+function getCardLines(card: Element): string[] {
+  return (card as HTMLElement).innerText
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
 }
 
 // Reads the packaging type from the format line under the product title, which
@@ -170,49 +253,25 @@ function getPackagingDescriptor(main: HTMLElement): null | string {
   return firstSegment ? firstSegment : null
 }
 
-// Systembolaget embeds the product data of the initially loaded page in
-// Next.js' __NEXT_DATA__ script; "packagingLevel1" is the packaging name
-// ("Flaska", "Box", …). Only trust it when an entry matches the current
-// product id — SPA navigations don't refresh the script.
+// Systembolaget embeds the data of the initially loaded page in Next.js'
+// __NEXT_DATA__ script; "packagingLevel1" is the packaging name ("Flaska",
+// "Box", …). A product page carries one product, a list page the first page of
+// results, so index whatever is there and only trust an entry that matches the
+// product being asked about — SPA navigations don't refresh the script.
+let packagingCache: null | { map: Map<string, string>; raw: string } = null
+
 function getPackagingFromPageData(productId: string): null | string {
   const raw = document.getElementById('__NEXT_DATA__')?.textContent
   if (!raw) {
     return null
   }
 
-  let fallback: Record<string, unknown>
-  try {
-    const parsed = JSON.parse(raw) as {
-      props?: { pageProps?: { fallback?: Record<string, unknown> } }
-    }
-    fallback = parsed.props?.pageProps?.fallback ?? {}
-  } catch {
-    return null
+  if (packagingCache?.raw !== raw) {
+    packagingCache = { map: buildPackagingMap(raw), raw }
   }
-
-  for (const entry of Object.values(fallback)) {
-    if (typeof entry !== 'object' || entry === null) {
-      continue
-    }
-    const product = entry as {
-      packagingLevel1?: null | string
-      productNumber?: null | string
-    }
-    if (product.productNumber !== productId) {
-      continue
-    }
-    const packaging = product.packagingLevel1
-    return typeof packaging === 'string' && packaging
-      ? packaging.toLowerCase()
-      : null
-  }
-  return null
+  return packagingCache.map.get(productId) ?? null
 }
 
-// Products sold in several packagings replace the static format line with a
-// dropdown whose selected value reads "{packaging}, {volume} ml". Read the
-// current selection; requiring a volume keeps unrelated dropdowns (store
-// picker, quantity, …) from being mistaken for it.
 function getSelectedPackaging(main: HTMLElement): null | string {
   for (const el of main.querySelectorAll('select, [role="combobox"]')) {
     // The dropdown's hidden <select> has no options until the app hydrates,
@@ -225,4 +284,15 @@ function getSelectedPackaging(main: HTMLElement): null | string {
     }
   }
   return null
+}
+
+// Products sold in several packagings replace the static format line with a
+// dropdown whose selected value reads "{packaging}, {volume} ml". Read the
+// current selection; requiring a volume keeps unrelated dropdowns (store
+// picker, quantity, …) from being mistaken for it.
+// The packaging descriptor is short and already isolated ("Bag-in-Box",
+// "PET-flaska", "box, 3000 ml"), so a plain substring test is enough — unlike
+// the free-form card text NON_BOTTLE_PATTERN guards.
+function isNonBottlePackaging(descriptor: string): boolean {
+  return NON_BOTTLE_FORMATS.some((format) => descriptor.includes(format))
 }

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -70,6 +70,15 @@ async function handleListCard(card: Element) {
   const name = productUtils.getCardName(card)
   if (!productId || !name) return
 
+  // Vivino only rates bottled wine, same as on the product page — leave the
+  // card untouched rather than badge a box with a bottle's rating.
+  if (
+    productType === ProductType.Wine &&
+    !productUtils.isCardBottle(card, productId)
+  ) {
+    return
+  }
+
   const spinner = domUtils.injectCardSpinner(card, productId)
   if (!spinner) return
 


### PR DESCRIPTION
The product page refuses to rate wine that isn't bottled — Vivino has no
comparable rating for box/bag-in-box/PET — but list-page cards fetched and
badged them anyway, so the same wine showed a rating in the grid and
"finns inte på flaska" one click later (#124).

Gate wine cards on a new isCardBottle(), the list-page counterpart of
isBottle(). Packaging is read from two sources, in order:

- the __NEXT_DATA__ payload, now indexed by product number across the whole
  fallback object instead of only its top level, so it covers a list page's
  server-rendered results and not just a single product page. The parsed map
  is cached per payload, since it is now consulted once per card.
- the card's own detail lines below "Nr {productId}" otherwise, for cards the
  payload doesn't cover (later result pages, filters applied after load).
  Those lines are free-form, so formats match as whole words there —
  "Bag-in-Box" and "PET" hit, "Petit" and "fatlagrat" don't — and the name and
  category lines above the product number are left out of the scan.

As on the product page, unreadable packaging still means "assume bottle"
rather than dropping the rating. Beer and cider are untouched: Untappd rates
cans and kegs.

Adds productUtils unit tests over synthetic card markup, opting into a DOM
with a per-file happy-dom docblock so the other suites keep the node
environment.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J3NnHTE9iMNacho5jkAqKv